### PR TITLE
Add form creation and submission MCP tools

### DIFF
--- a/constants/constants.py
+++ b/constants/constants.py
@@ -158,3 +158,12 @@ AUTH_HEADER_KEY = 'Authorization'
 
 X_COW_SECURITY_CONTEXT = 'X-Cow-Security-Context'
 
+
+#forms
+URL_FORMS = "/v1/forms"
+URL_FORMS_DYNAMIC_OPTIONS = "/v1/forms/dynamic-options"
+URL_MY_FORMS = "/v2/aggregator/my-forms"
+URL_FORMS_FETCH = "/v1/forms/fetch"
+URL_USERS_ME = "/v1/users/me"
+URL_USER_FORMS_SUBMIT = "/v1/user-forms/submit-user-response"
+URL_FORMS_ELEMENTS_FILE_UPLOAD = "/v1/forms/elements-file-upload"

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import traceback
 
 from constants.constants import host
 from mcpconfig.config import mcp
+from tools.forms import forms
 from tools.general import general
 from utils.auth import CCowOAuthProvider
 from utils.debug import logger
@@ -39,6 +40,10 @@ if "assistant" in MCP_TOOLS:
 
 if "metric" in MCP_TOOLS:
     from tools.metrics import metrics
+
+if "forms" in MCP_TOOLS:
+    from prompts.forms import forms
+    from tools.forms import forms
 
 def signal_handler(sig, frame):
     print("Shutting down...")

--- a/mcptypes/forms_tool_types.py
+++ b/mcptypes/forms_tool_types.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, model_validator
+from typing import Any, List, Literal, Optional
+
+FormElementType = Literal[
+    "",
+    "Block",
+    "Statement Block",
+    "Short Text",
+    "Paragraph",
+    "Radio Button",
+    "Checkbox",
+    "Dropdown",
+    "File Upload",
+    "Matrix",
+    "Date",
+    "Date Range"
+]
+
+
+class FormElementOptionVO(BaseModel):
+    value: Optional[str] = "" 
+    points: Optional[int] = 0
+    label: Optional[str] = ""
+    defaultChecked: Optional[bool] = False
+    nextInSequence: Optional[int] = None
+
+    model_config = {"extra": "ignore"}
+
+
+class FormElementVO(BaseModel):
+    id: Optional[str] = Field(default="", alias="_id")
+    type: FormElementType = ""
+    sequence: Optional[int] = 0
+    isWriteInEnabled: Optional[bool] = False
+    title: Optional[str] = ""
+    points: Optional[int] = 0
+    footer: Optional[str] = ""
+    tags: Optional[List[Any]] = None
+    elements: Optional[List[FormElementVO]] = None
+    value: Optional[str] = ""
+    dynamicOptionsId: Optional[str] = ""
+    videoUrl: Optional[str] = ""
+    options: Optional[List[FormElementOptionVO]] = None
+    nextInSequence: Optional[int] = None
+    isRequired: Optional[bool] = False
+
+    model_config = {"extra": "ignore"}
+
+
+FormElementVO.model_rebuild()
+
+
+class FormVO(BaseModel):
+    id: Optional[str] = ""
+    name: Optional[str] = ""
+
+    model_config = {
+        "extra": "ignore"
+    }
+
+
+class FormListVO(BaseModel):
+    forms: Optional[List[FormVO]] = None
+    error: Optional[str] = ""
+
+
+class FormTagVO(BaseModel):
+    index: Optional[int] = 0
+    key: Optional[str] = ""
+    primary: Optional[bool] = False
+    values: Optional[List[str]] = None
+
+    model_config = {"extra": "ignore"}
+
+
+class FormTagsItemVO(BaseModel):
+    key: Optional[str] = ""
+    values: Optional[List[str]] = None
+
+    model_config = {"extra": "ignore"}
+
+
+class CreateFormVO(BaseModel):
+    name: str  # required; keep same as form title
+    title: Optional[str] = None
+    elements: Optional[List[Any]] = None
+    type: Optional[str] = ""
+    tag: Optional[List[FormTagVO]] = None
+    isQuiz: Optional[bool] = False
+    totalPoints: Optional[int] = 0
+    # scoringLogic: Optional[List[Any]] = None
+
+    model_config = {"extra": "ignore"}
+
+    @model_validator(mode="after")
+    def sync_title_with_name(self) -> "CreateFormVO":
+        """Keep form title same as form name when title is not set."""
+        if self.title is None or self.title == "":
+            object.__setattr__(self, "title", self.name)
+        return self
+
+    def to_payload(self) -> dict:
+        """Build API payload with defaults for missing fields."""
+        tag_payload = (
+            [
+                {
+                    "index": t.index or 0,
+                    "key": t.key or "",
+                    "primary": t.primary if t.primary is not None else False,
+                    "values": t.values if t.values is not None else [],
+                }
+                for t in self.tag
+            ]
+            if self.tag is not None
+            else []
+        )
+        title = self.title if self.title else self.name
+        return {
+            "name": self.name,
+            "title": title,
+            "elements": (
+                [e.model_dump(exclude_none=False, exclude={"id"}) for e in self.elements]
+                if self.elements is not None
+                else []
+            ),
+            "type": self.type or "",
+            "tag": tag_payload,
+            "isQuiz": self.isQuiz if self.isQuiz is not None else False,
+            "totalPoints": self.totalPoints if self.totalPoints is not None else 0,
+            "scoringLogic": [],
+        }
+
+
+class CreateFormResponseVO(BaseModel):
+    form: Optional[FormVO] = None
+    error: Optional[str] = ""
+
+
+class UpdateFormVO(BaseModel):
+    name: str  # required; keep same as form title
+    title: Optional[str] = None
+    isQuiz: Optional[bool] = False
+    totalPoints: Optional[int] = 0
+    elements: Optional[List[FormElementVO]] = None
+    type: Optional[str] = ""
+    tags: Optional[List[FormTagsItemVO]] = None
+
+    model_config = {"extra": "ignore"}
+
+    def to_payload(self) -> dict:
+        """Build API payload (no _id). Serializes elements and tags."""
+        elements_payload = (
+            [e.model_dump(exclude_none=False, exclude={"id"}) for e in self.elements]
+            if self.elements is not None
+            else []
+        )
+        tags_payload = (
+            [{"key": t.key or "", "values": t.values if t.values is not None else []} for t in self.tags]
+            if self.tags is not None
+            else None
+        )
+        title = self.title if self.title else self.name
+        return {
+            "name": self.name,
+            "title": title,
+            "isQuiz": self.isQuiz if self.isQuiz is not None else False,
+            "totalPoints": self.totalPoints if self.totalPoints is not None else 0,
+            "elements": elements_payload,
+            "type": self.type or "",
+            "tags": tags_payload,
+        }
+
+
+class UpdateFormResponseVO(BaseModel):
+    form: Optional[FormVO] = None
+    error: Optional[str] = ""
+
+
+class DynamicOptionVO(BaseModel):
+    id: Optional[str] = ""
+    name: Optional[str] = ""
+    status: Optional[Any] = None  # True or "active" means active
+
+    model_config = {"extra": "ignore"}
+
+
+class DynamicOptionListVO(BaseModel):
+    items: Optional[List[DynamicOptionVO]] = None
+    error: Optional[str] = ""
+
+
+class DynamicOptionDetailVO(BaseModel):
+    id: Optional[str] = ""
+    name: Optional[str] = ""
+    status: Optional[Any] = None
+    options: Optional[List[FormElementOptionVO]] = None
+
+    model_config = {"extra": "ignore"}
+
+
+class DynamicOptionDetailResponseVO(BaseModel):
+    dynamic_option: Optional[DynamicOptionDetailVO] = None
+    error: Optional[str] = ""
+
+
+class AssignedFormVO(BaseModel):
+    id: Optional[str] = ""  # form assignment id
+    formID: Optional[str] = ""
+    formName: Optional[str] = ""
+    dueDate: Optional[str] = ""
+    displayableDueDate: Optional[str] = ""
+    displayableAssignedOn: Optional[str] = ""
+    assignedBy: Optional[str] = ""
+    purpose: Optional[str] = ""
+    createdAt: Optional[str] = ""
+    tags: Optional[Any] = None
+    elements: Optional[List[str]] = None 
+
+    model_config = {"extra": "ignore"}
+
+
+class AssignedFormListVO(BaseModel):
+    items: Optional[List[AssignedFormVO]] = None
+    error: Optional[str] = ""
+
+
+class FormDetailVO(BaseModel):
+    id: Optional[str] = ""
+    name: Optional[str] = ""
+    title: Optional[str] = ""
+    isQuiz: Optional[bool] = False
+    totalPoints: Optional[int] = 0
+    elements: Optional[List[FormElementVO]] = None
+    type: Optional[str] = ""
+    tags: Optional[List[FormTagsItemVO]] = None
+
+    model_config = {"extra": "ignore"}
+
+
+class FormDetailResponseVO(BaseModel):
+    form: Optional[FormDetailVO] = None
+    error: Optional[str] = ""
+
+
+class FormProgressVO(BaseModel):
+    items: Optional[dict[str, Any]] = None
+    totalQuestions: Optional[int] = None
+    formResponseId: Optional[str] = ""
+    totalScore: Optional[int] = None
+    totalPoints: Optional[int] = None
+    status: Optional[str] = ""
+
+    model_config = {"extra": "ignore"}
+
+
+class FormProgressResponseVO(BaseModel):
+    progress: Optional[FormProgressVO] = None
+    error: Optional[str] = ""
+
+
+class CreateFormResponsePayloadVO(BaseModel):
+    formId: str
+    userId: str
+    assignId: str
+
+    model_config = {"extra": "ignore"}
+
+
+class CreateFormResponseResultVO(BaseModel):
+    id: Optional[str] = ""
+
+    model_config = {"extra": "ignore"}
+
+
+class CreateFormResponseResponseVO(BaseModel):
+    form_response: Optional[CreateFormResponseResultVO] = None
+    error: Optional[str] = ""
+
+
+class CurrentUserVO(BaseModel):
+    ID: Optional[str] = ""
+    emailid: Optional[str] = ""
+    username: Optional[str] = ""
+
+    model_config = {"extra": "ignore"}
+
+
+class CurrentUserResponseVO(BaseModel):
+    user: Optional[CurrentUserVO] = None
+    error: Optional[str] = ""
+
+
+class SaveFormResponsesPayloadVO(BaseModel):
+    formResponseId: str
+    formResponses: dict[str, Any]  # element_id -> str | {toDate, fromDate} | list[{bucketName, filePath, fileName, fileHash}]
+
+    model_config = {"extra": "ignore"}
+
+
+class SaveFormResponsesResponseVO(BaseModel):
+    success: Optional[bool] = None
+    error: Optional[str] = ""
+
+
+class SubmitUserFormPayloadVO(BaseModel):
+
+    userID: str
+    myformID: str  # assign_id
+    formID: str
+
+    model_config = {"extra": "ignore"}
+
+
+class SubmitUserFormResponseVO(BaseModel):
+    success: Optional[bool] = None
+    error: Optional[str] = ""
+
+
+class FormElementFileUploadResultVO(BaseModel):
+    bucketName: Optional[str] = ""
+    filePath: Optional[str] = ""
+    fileName: Optional[str] = ""
+    fileHash: Optional[str] = ""
+
+    model_config = {"extra": "ignore"}
+
+
+class FormElementFileUploadResponseVO(BaseModel):
+    files: Optional[List[FormElementFileUploadResultVO]] = None
+    error: Optional[str] = ""

--- a/prompts/forms/form_knowledge.md
+++ b/prompts/forms/form_knowledge.md
@@ -1,0 +1,250 @@
+FORM OVERVIEW
+=================
+ A form in complianceow is a tool that collects structured inputs using question types.
+
+ A form is primarily used for conducting surveys, feedback, and security/compliance questionnaires.
+
+------------------------------------------------------------
+QUESTIONS
+--------------
+A question is the atomic building block of a form.
+
+Each question has:
+- a label (title) shown to the user
+- a question type (how input is captured)
+- optional helper text (footer)
+- requiredness
+- an order position (sequence)
+- additional behavior that depends on the question type (for example: containers, grids, option-jumps, scoring)
+
+------------------------------------------------------------
+QUESTION TYPES
+--------------
+Forms support the following question types. Use the appropriate type based on the kind of input or content you need.
+
+1. BLOCK
+-------------
+Definition:
+A structural container or section used to group related questions or content. Does not collect a direct answer, It may holds child question types.
+
+2. STATEMENT BLOCK
+-------------
+Definition:
+A block that displays static text, instructions, or statements. Used to provide context or guidance without requiring user input.
+
+3. SHORT TEXT
+-------------
+Definition:
+Single-line free text input. Accepts a short string (e.g. name, ID, code, single phrase).
+
+4. PARAGRAPH
+-------------
+Definition:
+Multi-line free text input. Accepts longer prose, descriptions, or comments.
+
+5. RADIO BUTTON
+-------------
+Definition:
+Single-choice selection from a fixed list of options. Only one option can be selected.
+
+
+6. CHECKBOX
+-------------
+Definition:
+Multi-choice selection from a fixed list. One or more options can be selected.
+
+7. DROPDOWN
+-------------
+Definition:
+Single-choice selection from a list presented in a dropdown menu. Compact alternative to radio when many options exist. Also supports write-in input when write-in is enabled.
+
+
+8. FILE UPLOAD
+-------------
+Definition:
+Control that allows the respondent to attach or upload one or more files (e.g. documents, images).
+
+9. MATRIX
+-------------
+- A matrix is a grid-like container where each row is an answerable sub-question.
+- Row question type is restricted: every row must be either `Radio Button` or `Checkbox` only (one type per matrix; do not mix).
+- All rows in a Matrix must have the **same option set** (same order and meaning; point values apply consistently for quiz scoring).
+
+When to use Matrix question type:
+- Use a Matrix when the form needs to capture the **same set of options** for multiple, related items, using either `Radio Button` or `Checkbox`.
+- **Compliance example (radio)**: quarterly access certification where an approver must `Approve` / `Revoke` each user’s role across a list of applications.
+- **Security posture example (checkbox)**: periodic privilege review where a security admin selects which entitlements (e.g. `Read`, `Write`, `Admin`) should remain for each service account.
+
+10. DATE
+-------------
+Definition: 
+Single date picker. Captures a calendar date (day, month, year), the date format is MM/DD/YYYY.
+
+11. DATE RANGE
+-------------
+Definition:
+Start and end date pickers. Captures a period (e.g. project duration, validity window), the date format is MM/DD/YYYY.
+
+------------------------------------------------------------
+FORM CREATION RULES
+--------------------
+
+Dynamic options
+--------------
+- Dynamic options provide a reusable preset list of options for option-type questions (Radio Button, Checkbox, Dropdown).
+- Always include a static fallback options list. Dynamic options may be unavailable, but the form must remain usable.
+
+Jump configuration
+--------------
+- Jump configuration redirects the next step based on the option selected.
+- Example: Jump configuration reference (design-time)
+  - Question configuration indicates that options may contain jump directives.
+  - At runtime, each option’s directive is interpreted as:
+    - `nextInSequence: -2` => jump directly to submission
+    - `nextInSequence: -3` => treat as “no jump”; follow default traversal order
+    - `nextInSequence: <n>` => jump to the question whose configured sequence matches `<n>`
+
+Enable write in
+--------------
+- Write-in is supported only for `Dropdown` questions.
+- When write-in is enabled, the respondent can choose an option or enter a custom value.
+
+Example: Write-in flag (design-time)
+- `isWriteInEnabled: true`
+
+Form quiz
+--------------
+- Quiz/scoring mode enables point-based scoring for option selections.
+- When quiz mode is enabled, each option should define its point value.
+
+Example: Quiz/scoring mode (design-time)
+- `isQuiz: true`
+- Each option includes `points`
+
+
+
+Example: Single question payload (Radio Button, design-time)
+---------------------------------------------------------------
+Use this structure when defining a Radio Button question inside a form. Placeholders are values you set while creating the form.
+
+```json
+{
+  "type": "Radio Button",
+  "title": "{{question_title}}",
+  "footer": "{{question_footer}}",
+  "isRequired": {{is_required}},
+  "sequence": {{sequence_index}},
+  "tags": ["{{tag_value_1}}", "{{tag_value_2}}"],
+  "points": {{question_points_max}},
+  "nextInSequence": {{question_level_jump_flag}},
+  "options": [
+    {
+      "value": "{{option_value_string_index}}",
+      "label": "{{option_label}}",
+      "points": {{option_points}},
+      "defaultChecked": {{default_checked}},
+      "nextInSequence": {{option_level_jump_directive}}
+    }
+  ]
+}
+```
+
+Field meanings (placeholders)
+- `type`: Question type. Use `"Radio Button"`.
+- `title`: Question label shown to the user (`{{question_title}}`).
+- `footer`: Helper text shown under the question (`{{question_footer}}`).
+- `isRequired`: Whether the user must answer (`{{is_required}}`).
+- `sequence`: Ordering position within the form (`{{sequence_index}}`).
+- `tags`: Optional metadata list (`{{tag_value_1}}`, `{{tag_value_2}}`).
+- `points`: Maximum points for quiz scoring (`{{question_points_max}}`).
+- `nextInSequence`: Question-level jump configuration flag (`{{question_level_jump_flag}}`).
+- `options`: Selectable answers list.
+  - `value`: Stored option identifier saved as the answer (`{{option_value_string_index}}`). This is the string index/value.
+  - `label`: Option text shown to the user (`{{option_label}}`).
+  - `points`: Points awarded if selected in quiz mode (`{{option_points}}`).
+  - `defaultChecked`: Whether this option is pre-selected (`{{default_checked}}`).
+  - `nextInSequence`: Option-level navigation directive (`{{option_level_jump_directive}}`).
+
+OPERATIONAL RULES FOR FORM CREATION / UPDATES
+------------------------------------------------
+- Before creating or changing a form, prepare a plan (purpose, question types, order, scoring/jump logic) and ask for explicit user confirmation.
+- After creating a form, show the form name and form id; keep the form id for later modifications.
+- When modifying an existing form, update that form instead of creating a new one.
+- If the request to “update/change the form” is ambiguous, ask which form to modify (by name or by id) or use the form id from the current conversation.
+- If the requirement is vague (e.g. “add some questions”, “make a survey”), do not guess: ask the minimum clarifying question(s), one at a time; after each answer, acknowledge and continue.
+- Use only question types and structures documented in this file.
+- For `Radio Button`, `Checkbox`, and `Dropdown`, always provide options; use dynamic options only when intended; keep sequence consistent when adding/reordering.
+- For `Matrix`, ensure every child row uses the same option set; when you change an option label/meaning in one row, apply it to all rows in that matrix.
+
+FORM SUBMISSION RULES
+-----------------------
+
+PRE-SUBMISSION CONFIRMATION RULE
+- Before final submission, show a human-readable summary of what the user filled so far.
+- Proceed with submission ONLY after the user explicitly confirms.
+
+RESUME / START-OVER RULE
+- Load the saved progress for the current form and assignment.
+- If no answers have been saved yet:
+  - Start collecting from the first answerable question in traversal order.
+- If some answers have been saved already:
+  - Ask whether the user wants to `continue` (resume) or `start over`.
+  - If the user chooses `continue`:
+    - Traverse the form in declared order to build the ordered list of answerable question identifiers.
+    - Start from the first answerable identifier that has no saved answer yet.
+  - If the user chooses `start over`:
+    - Start from the first answerable question again.
+    - Overwrite previously saved answers as the user re-enters them.
+
+TRAVERSAL RULES (STRUCTURE)
+- `Block` and `Statement Block`:
+  - Do not ask for a direct answer.
+  - Recursively traverse nested questions in declared order.
+- `Matrix`:
+  - Treat each child row question as answerable.
+  - Collect each row’s answer in increasing order.
+
+INPUT COLLECTION RULES (ONE QUESTION AT A TIME)
+- Ask exactly one question per step.
+- After the user answers a question:
+  - Persist ONLY that single answer into the current in-progress response mapping.
+  - Update the local “answered set” so navigation decisions are correct.
+- Do not batch multiple question answers in a single step.
+
+NEXT-QUESTION SELECTION RULE (JUMP LOGIC)
+- Default: always follow traversal order to the next answerable question.
+- Jump logic applies only to option-type questions: `Radio Button` and `Dropdown`.
+- When jump directives are enabled for the selected option:
+  - If the directive indicates “jump to submission”, end the traversal and submit.
+  - If the directive indicates “no jump”, fall back to default traversal order.
+  - Otherwise, jump to the question whose configured sequence/order matches the directive target.
+
+FILE UPLOAD RULE
+- Never request raw file bytes inside chat.
+- For the current `File Upload` question:
+  - Provide the user the UI upload URL:
+    - `host+"/ui/display-form?assign_id={{assign_id}}"`
+  - Ask the user to complete the upload in the UI.
+  - After upload completion is confirmed by the user:
+    - Reload saved progress.
+    - Proceed only once the saved answer for this upload question is available.
+
+SUBMIT RULE
+- When traversal ends (or jump indicates submission):
+  - Build a human-readable summary using the form’s question labels and the user’s saved selections.
+  - Show the summary and request explicit confirmation.
+  - If confirmed: submit the form for the current user + assignment.
+  - If declined: ask whether to `continue editing` (resume) or `start over`.
+
+EXAMPLES (wire-format only; keep these details out of normal explanations)
+- Saved progress view:
+  - `progress.items`: mapping of answered `element_id` -> stored answer
+  - `progress.formResponseId`: the saved response/session identifier used while saving answers
+- Option answer encoding:
+  - For option-type questions, persist the selected option’s configured `value` (string index/value), not the label.
+- Jump directive reference (runtime interpretation):
+  - `nextInSequence: -2` => jump to submission
+  - `nextInSequence: -3` => no jump; use default traversal
+  - `nextInSequence: <n>` => jump to question sequence/order `<n>`
+
+ 

--- a/prompts/forms/forms.py
+++ b/prompts/forms/forms.py
@@ -1,0 +1,17 @@
+import os
+
+from mcpconfig.config import mcp
+
+
+@mcp.prompt()
+def form_knowledge() -> str:
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    
+    general_path = os.path.join(script_dir, "form_knowledge.md")
+
+    general = ""
+
+    with open(general_path, "r") as file:
+        general = file.read()
+
+    return general

--- a/tools/forms/forms.py
+++ b/tools/forms/forms.py
@@ -1,0 +1,769 @@
+
+import copy
+import traceback
+from typing import Any, Dict, List
+
+from fastmcp import Context
+
+from constants import constants
+from mcpconfig.config import mcp
+from mcptypes import forms_tool_types as vo
+from utils import utils
+from utils.debug import logger
+
+
+def _normalize_matrix_options(elements: List[Any]) -> None:
+    """For each Matrix element, sync all children's options to the first child's options (mutates in place). Recurses into Block/Statement Block/Matrix."""
+    if not elements:
+        return
+    for item in elements:
+        if not isinstance(item, dict):
+            continue
+        child_elements = item.get("elements")
+        if isinstance(child_elements, list):
+            if item.get("type") == "Matrix" and len(child_elements) > 0:
+                first_options = child_elements[0].get("options")
+                if first_options is not None:
+                    first_options_copy = copy.deepcopy(first_options)
+                    for child in child_elements[1:]:
+                        if isinstance(child, dict) and child.get("type") in (
+                            "Radio Button",
+                            "Checkbox",
+                        ):
+                            child["options"] = copy.deepcopy(first_options_copy)
+            _normalize_matrix_options(child_elements)
+
+
+@mcp.tool()
+async def list_forms(ctx: Context | None = None) -> vo.FormListVO:
+    """
+        Get all forms
+
+        Returns:
+            - forms (List[FormVO]): A list of forms. Each form has:
+                - id (str): Form id.
+                - name (str): Form name.
+            - error (Optional[str]): An error message if any issues occurred during retrieval.
+    """
+    try:
+        logger.info("list_forms: \n")
+
+        output = await utils.make_API_call_to_CCow_and_get_response(constants.URL_FORMS, "GET", ctx)
+        logger.debug("list_forms output: {}\n".format(output))
+        if isinstance(output, str) or "error" in output:
+            logger.error("list_forms error: {}\n".format(output))
+            return vo.FormListVO(error="Facing internal error")
+
+        forms: List[vo.FormVO] = []
+        for item in output:
+            forms.append(
+                vo.FormVO(
+                    id=item.get("_id", ""),
+                    name=item.get("name", ""),
+                )
+            )
+
+        return vo.FormListVO(forms=forms)
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("list_forms error: {}\n".format(e))
+        return vo.FormListVO(error="Facing internal error")
+
+@mcp.tool()
+async def create_form(form: vo.CreateFormVO, ctx: Context | None = None) -> vo.CreateFormResponseVO:
+    """
+    Create a form
+
+    Args:
+        form: Form creation payload with:
+            - name (str): Form name (required). Keep form name same as form title.
+            - title (Optional[str]): Form title; when omitted, kept same as name.
+            - elements (Optional[List[FormElementVO]]): Form elements (questions/widgets). Each element has:
+               - type (str): Only allowed values: "Block", "Statement Block", "Short Text", "Paragraph", "Radio Button", "Checkbox", "Dropdown", "File Upload", "Matrix", "Date", "Date Range".
+               - title (str): The question label or heading shown to the user (do not put this in footer).
+               - footer (str): Optional helper or hint text shown below the question (e.g. instructions); separate from title.
+               - sequence (int): Order of the element (0, 1, 2, ...).
+               - isRequired (bool): Whether the question must be answered.
+               - points (int): Max points for quiz; for option types, points can also be on each option.
+               - elements (list): Nested child elements for "Block" or "Statement Block"; for "Matrix", must be list of "Radio Button" or "Checkbox" only; each child must have the same set of options; changing an option label in one child must be reflected in all children of that matrix.
+               - options (list): For "Radio Button", "Checkbox", "Dropdown": list of {value (index as string which identifies the option item), label, points, defaultChecked, nextInSequence}; list.
+               - isWriteInEnabled (bool): For "Dropdown" only; allows free-text input.
+               - nextInSequence (int): For option types, -3 means options have jump config; in options, -2 means jump to form submission.
+               - videoUrl (str): Optional; when set, holds a video URL to be rendered as an embedded video card for that element.
+               - tags, value, dynamicOptionsId: Optional; use when relevant.
+            - tags (Optional[List[FormTagsItemVO]]): Tags for the form. Each item has:
+                - index (int): Tag index.
+                - key (str): Tag key.
+                - primary (bool): Whether this tag is primary.
+                - values (List[str]): Tag values (e.g. ["asdf"]).
+            - isQuiz (Optional[bool]): Whether the form is a quiz (default False).
+            - totalPoints (Optional[int]): Total points (default 0).
+
+    Returns:
+        - form (Optional[FormVO]): Created form with id and name.
+        - error (Optional[str]): Error message if creation failed.
+    """
+    try:
+        logger.info("create_form: name=%s", form.name or form.title)
+
+        payload = form.to_payload()
+        if payload.get("elements"):
+            _normalize_matrix_options(payload["elements"])
+        output = await utils.make_API_call_to_CCow_and_get_response(
+            constants.URL_FORMS, "POST", payload, ctx=ctx
+        )
+        logger.debug("create_form output: %s", output)
+
+        if isinstance(output, str):
+            logger.error("create_form error: %s", output)
+            return vo.CreateFormResponseVO(error=output or "Facing internal error")
+        if isinstance(output, dict) and output.get("error"):
+            logger.error("create_form error: %s", output)
+            return vo.CreateFormResponseVO(error=output.get("error", "Facing internal error"))
+        if isinstance(output, dict) and "Message" in output:
+            return vo.CreateFormResponseVO(
+                error=output.get("Description") or output.get("Message", "Request failed")
+            )
+
+        # Success: response may be the created form object (e.g. _id, name)
+        created = output if isinstance(output, dict) else {}
+        form_id = created.get("_id") or created.get("id", "")
+        form_name = created.get("name") or created.get("title", "")
+
+        return vo.CreateFormResponseVO(
+            form=vo.FormVO(id=form_id, name=form_name)
+        )
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("create_form error: %s", e)
+        return vo.CreateFormResponseVO(error="Facing internal error")
+
+
+@mcp.tool()
+async def update_form(
+    form_id: str,
+    form: vo.UpdateFormVO,
+    ctx: Context | None = None,
+) -> vo.UpdateFormResponseVO:
+    """
+    Update an existing form.
+
+    This function is used to update an existing form using form id and payload.
+
+    Args:
+        form_id: Form ID to update.
+        form: Update payload with:
+            - name (str): Form name (required). Keep form name same as form title.
+            - title (Optional[str]): Form title; when omitted, kept same as name.
+            - isQuiz (Optional[bool]): Whether the form is a quiz (default False).
+            - totalPoints (Optional[int]): Total points (default 0).
+            - elements (Optional[List[FormElementVO]]): Form elements (questions/widgets). Each element has:
+               - type (str): Only allowed values: "Block", "Statement Block", "Short Text", "Paragraph", "Radio Button", "Checkbox", "Dropdown", "File Upload", "Matrix", "Date", "Date Range".
+               - title (str): The question label or heading shown to the user (do not put this in footer).
+               - footer (str): Optional helper or hint text shown below the question (e.g. instructions); separate from title.
+               - sequence (int): Order of the element (0, 1, 2, ...).
+               - isRequired (bool): Whether the question must be answered.
+               - points (int): Max points for quiz; for option types, points can also be on each option.
+               - elements (list): Nested child elements for "Block"; for "Matrix", must be list of "Radio Button" or "Checkbox" only; each child must have the same set of options; changing an option label in one child must be reflected in all children of that matrix.
+               - options (list): For "Radio Button", "Checkbox", "Dropdown": list of {value (index as string which identifies the option item), label, points, defaultChecked, nextInSequence}; list.
+               - isWriteInEnabled (bool): For "Dropdown" only; allows free-text input along with the options.
+               - dynamicOptionsId (str): Dynamic option set id (e.g. from list_dynamic_options), if provided, the options will be replaced with the dynamic options for option type questions such as (Radio Button, Checkbox, Dropdown).
+               - nextInSequence (int):(Jump configuration) For option types, -3 means options have jump config; in options, -2 means jump to submit, to jump to specific question use `nextInSequence`: `{sequence_of_the_next_question_to_jump_to}`.
+               - videoUrl (str): Optional; when set, holds a video URL to be rendered as an embedded video card for that element.
+               - tags, value.
+            - type (Optional[str]): Form type (default "").
+            - tags (Optional[List[FormTagsItemVO]]): Tags for the form. Each item has:
+                - index (int): Tag index.
+                - key (str): Tag key.
+                - primary (bool): Whether this tag is primary.
+                - values (List[str]): Tag values (e.g. ["asdf"]).
+
+    Returns:
+        - form (Optional[FormVO]): Updated form with id and name (from request; API returns no body).
+        - error (Optional[str]): Error message if update failed.
+    """
+    try:
+        logger.info("update_form: form_id=%s", form_id)
+
+        url = f"{constants.URL_FORMS}/{form_id}"
+        payload = form.to_payload()
+        if payload.get("elements"):
+            _normalize_matrix_options(payload["elements"])
+        output = await utils.make_API_call_to_CCow_and_get_response(
+            url, "PUT", payload, ctx=ctx
+        )
+        logger.debug("update_form output: %s", output)
+
+        if isinstance(output, str):
+            logger.error("update_form error: %s", output)
+            return vo.UpdateFormResponseVO(error=output or "Facing internal error")
+        if isinstance(output, dict) and output.get("error"):
+            logger.error("update_form error: %s", output)
+            return vo.UpdateFormResponseVO(
+                error=output.get("error", "Facing internal error")
+            )
+        if isinstance(output, dict) and "Message" in output:
+            return vo.UpdateFormResponseVO(
+                error=output.get("Description") or output.get("Message", "Request failed")
+            )
+
+        return vo.UpdateFormResponseVO(
+            form=vo.FormVO(
+                id=form_id,
+                name=form.name or form.title or "",
+            )
+        )
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("update_form error: %s", e)
+        return vo.UpdateFormResponseVO(error="Facing internal error")
+
+
+def _is_dynamic_option_active(status) -> bool:
+    """True if status indicates active dynamic option"""
+    if status is True:
+        return True
+    if isinstance(status, str) and str(status).lower() == "active":
+        return True
+    return False
+
+
+@mcp.tool()
+async def list_dynamic_options(ctx: Context | None = None) -> vo.DynamicOptionListVO:
+    """
+    List dynamic options. Returns only id, name, and status.
+    Only includes dynamic option sets with status active.
+
+    Returns:
+        - items (List[DynamicOptionVO]): Each item has id, name, status.
+        - error (Optional[str]): Error message if the request failed.
+    """
+    try:
+        logger.info("list_dynamic_options")
+
+        output = await utils.make_API_call_to_CCow_and_get_response(
+            constants.URL_FORMS_DYNAMIC_OPTIONS, "GET", ctx=ctx
+        )
+        logger.debug("list_dynamic_options output: %s", output)
+
+        if isinstance(output, str) or (isinstance(output, dict) and "error" in output):
+            logger.error("list_dynamic_options error: %s", output)
+            return vo.DynamicOptionListVO(error="Facing internal error")
+        if isinstance(output, dict) and "Message" in output:
+            return vo.DynamicOptionListVO(
+                error=output.get("Description") or output.get("Message", "Request failed")
+            )
+
+        items_raw = output.get("items") if isinstance(output, dict) else []
+        if not isinstance(items_raw, list):
+            items_raw = []
+
+        items: List[vo.DynamicOptionVO] = []
+        for item in items_raw:
+            if not isinstance(item, dict):
+                continue
+            status = item.get("status")
+            if not _is_dynamic_option_active(status):
+                continue
+            items.append(
+                vo.DynamicOptionVO(
+                    id=item.get("_id", ""),
+                    name=item.get("name", ""),
+                    status=status,
+                )
+            )
+
+        return vo.DynamicOptionListVO(items=items)
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("list_dynamic_options error: %s", e)
+        return vo.DynamicOptionListVO(error="Facing internal error")
+
+
+@mcp.tool()
+async def fetch_dynamic_option(
+    dynamic_option_id: str,
+    ctx: Context | None = None,
+) -> vo.DynamicOptionDetailResponseVO:
+    """
+    Fetch a single dynamic option by id. Only returns data when the dynamic option set has status active.
+
+    Args:
+        dynamic_option_id: The dynamic option set id (e.g. from list_dynamic_options).
+
+    Returns:
+        - dynamic_option (Optional[DynamicOptionDetailVO]): id, name, status, options. Present only when status is active.
+        - error (Optional[str]): Error message if the request failed or the option is not active.
+    """
+    try:
+        logger.info("fetch_dynamic_option: id=%s", dynamic_option_id)
+
+        url = f"{constants.URL_FORMS_DYNAMIC_OPTIONS}/{dynamic_option_id}"
+        output = await utils.make_API_call_to_CCow_and_get_response(url, "GET", ctx=ctx)
+        logger.debug("fetch_dynamic_option output: %s", output)
+
+        if isinstance(output, str):
+            logger.error("fetch_dynamic_option error: %s", output)
+            return vo.DynamicOptionDetailResponseVO(error=output or "Facing internal error")
+        if isinstance(output, dict) and output.get("error"):
+            return vo.DynamicOptionDetailResponseVO(
+                error=output.get("error", "Facing internal error")
+            )
+        if isinstance(output, dict) and "Message" in output:
+            return vo.DynamicOptionDetailResponseVO(
+                error=output.get("Description") or output.get("Message", "Request failed")
+            )
+
+        if not isinstance(output, dict):
+            return vo.DynamicOptionDetailResponseVO(error="Invalid response")
+
+        status = output.get("status")
+        if not _is_dynamic_option_active(status):
+            return vo.DynamicOptionDetailResponseVO(
+                error="Dynamic option is not active; only active dynamic option sets can be used."
+            )
+
+        options_raw = output.get("options") or []
+        options_list: List[vo.FormElementOptionVO] = []
+        if isinstance(options_raw, list):
+            for opt in options_raw:
+                if isinstance(opt, dict):
+                    try:
+                        options_list.append(vo.FormElementOptionVO(**opt))
+                    except Exception:
+                        options_list.append(vo.FormElementOptionVO())
+
+        return vo.DynamicOptionDetailResponseVO(
+            dynamic_option=vo.DynamicOptionDetailVO(
+                id=output.get("_id", ""),
+                name=output.get("name", ""),
+                status=status,
+                options=options_list,
+            )
+        )
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("fetch_dynamic_option error: %s", e)
+        return vo.DynamicOptionDetailResponseVO(error="Facing internal error")
+
+
+@mcp.tool()
+async def list_forms_assigned_to_me(ctx: Context | None = None) -> vo.AssignedFormListVO:
+    """
+    List forms assigned to the current user. Use this when the user asks to fill a form
+    assigned to them or to see their assigned forms.
+
+    Returns:
+        - items (List[AssignedFormVO]): Each item has: id (form assignment id), formID (unique form id),
+          formName, dueDate, displayableDueDate, displayableAssignedOn, assignedBy, purpose, createdAt, tags.
+        - error (Optional[str]): Error message if the request failed.
+    """
+    try:
+        logger.info("list_forms_assigned_to_me")
+
+        output = await utils.make_API_call_to_CCow_and_get_response(
+            constants.URL_MY_FORMS, "GET", ctx=ctx
+        )
+        logger.debug("list_forms_assigned_to_me output: %s", output)
+
+        if isinstance(output, str):
+            logger.error("list_forms_assigned_to_me error: %s", output)
+            return vo.AssignedFormListVO(error=output or "Facing internal error")
+        if isinstance(output, dict) and output.get("error"):
+            return vo.AssignedFormListVO(error=output.get("error", "Facing internal error"))
+        if isinstance(output, dict) and "Message" in output:
+            return vo.AssignedFormListVO(
+                error=output.get("Description") or output.get("Message", "Request failed")
+            )
+
+        items_raw = output.get("items") if isinstance(output, dict) else []
+        if not isinstance(items_raw, list):
+            items_raw = []
+
+        items: List[vo.AssignedFormVO] = []
+        for item in items_raw:
+            if not isinstance(item, dict):
+                continue
+            items.append(
+                vo.AssignedFormVO(
+                    id=item.get("id", ""),
+                    formID=item.get("formID", ""),
+                    formName=item.get("formName", ""),
+                    dueDate=item.get("dueDate", ""),
+                    displayableDueDate=item.get("displayableDueDate", ""),
+                    displayableAssignedOn=item.get("displayableAssignedOn", ""),
+                    assignedBy=item.get("assignedBy", ""),
+                    purpose=item.get("purpose", ""),
+                    createdAt=item.get("createdAt", ""),
+                    tags=item.get("tags"),
+                )
+            )
+
+        return vo.AssignedFormListVO(items=items)
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("list_forms_assigned_to_me error: %s", e)
+        return vo.AssignedFormListVO(error="Facing internal error")
+
+
+@mcp.tool()
+async def fetch_complete_form(
+    form_id: str,
+    assign_id: str,
+    ctx: Context | None = None,
+) -> vo.FormDetailResponseVO:
+    """
+    Fetch the complete form definition by form id, including all elements (questions/widgets).
+
+    Args:
+        form_id: The form id (e.g. formID from an item returned by list_forms_assigned_to_me).
+
+    Returns:
+        - form (Optional[FormDetailVO]): Full form with id, name, title, isQuiz, totalPoints, elements, type, tags.
+        - error (Optional[str]): Error message if the request failed.
+    """
+    try:
+        logger.info("fetch_complete_form: form_id=%s, assign_id=%s", form_id, assign_id)
+
+        payload = {"formId": form_id, "assignId": assign_id}
+        output = await utils.make_API_call_to_CCow_and_get_response(
+            constants.URL_FORMS_FETCH, "POST", payload, ctx=ctx
+        )
+        logger.debug("fetch_complete_form output: %s", output)
+
+        if isinstance(output, str):
+            logger.error("fetch_complete_form error: %s", output)
+            return vo.FormDetailResponseVO(error=output or "Facing internal error")
+        if isinstance(output, dict) and output.get("error"):
+            return vo.FormDetailResponseVO(
+                error=output.get("error", "Facing internal error")
+            )
+        if isinstance(output, dict) and "Message" in output:
+            return vo.FormDetailResponseVO(
+                error=output.get("Description") or output.get("Message", "Request failed")
+            )
+
+        if not isinstance(output, dict):
+            return vo.FormDetailResponseVO(error="Invalid response")
+
+        elements_raw = output.get("elements") or []
+        elements_list: List[vo.FormElementVO] = []
+        if isinstance(elements_raw, list):
+            for elem in elements_raw:
+                if isinstance(elem, dict):
+                    try:
+                        # `FormElementVO.id` is sourced from the API's `_id`.
+                        elements_list.append(vo.FormElementVO(**elem))
+                    except Exception:
+                        pass
+
+        tags_raw = output.get("tags") or []
+        tags_list: List[vo.FormTagsItemVO] = []
+        if isinstance(tags_raw, list):
+            for t in tags_raw:
+                if isinstance(t, dict):
+                    tags_list.append(
+                        vo.FormTagsItemVO(
+                            key=t.get("key", ""),
+                            values=t.get("values") if t.get("values") is not None else [],
+                        )
+                    )
+
+        form_detail = vo.FormDetailVO(
+            id=output.get("_id", ""),
+            name=output.get("name", ""),
+            title=output.get("title", ""),
+            isQuiz=output.get("isQuiz", False),
+            totalPoints=output.get("totalPoints", 0),
+            type=output.get("type", ""),
+            tags=tags_list if tags_list else None,
+            elements=elements_list,
+        )
+        return vo.FormDetailResponseVO(form=form_detail)
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("fetch_complete_form error: %s", e)
+        return vo.FormDetailResponseVO(error="Facing internal error")
+
+
+@mcp.tool()
+async def check_form_progress(
+    form_id: str,
+    assign_id: str,
+    ctx: Context | None = None,
+) -> vo.FormProgressResponseVO:
+    """
+    Check form progress: answers filled so far for the given form and assignment.
+    If items has length > 0, the form has been at least partially filled by the assigned user.
+
+    Args:
+        form_id: The form id (e.g. formID from list_forms_assigned_to_me).
+        assign_id: The form assignment id (id from list_forms_assigned_to_me).
+
+    Returns:
+        - progress (Optional[FormProgressVO]): items (element id -> answer), totalQuestions,
+          formResponseId, totalScore, totalPoints, status.
+        - error (Optional[str]): Error message if the request failed.
+    """
+    try:
+        logger.info("check_form_progress: form_id=%s, assign_id=%s", form_id, assign_id)
+
+        url = f"{constants.URL_FORMS}/{form_id}/response/{assign_id}/progress"
+        output = await utils.make_API_call_to_CCow_and_get_response(url, "GET", ctx=ctx)
+        logger.debug("check_form_progress output: %s", output)
+
+        if isinstance(output, str):
+            logger.error("check_form_progress error: %s", output)
+            return vo.FormProgressResponseVO(error=output or "Facing internal error")
+        if isinstance(output, dict) and output.get("error"):
+            return vo.FormProgressResponseVO(
+                error=output.get("error", "Facing internal error")
+            )
+        if isinstance(output, dict) and "Message" in output:
+            return vo.FormProgressResponseVO(
+                error=output.get("Description") or output.get("Message", "Request failed")
+            )
+
+        if not isinstance(output, dict):
+            return vo.FormProgressResponseVO(error="Invalid response")
+
+        progress = vo.FormProgressVO(
+            items=output.get("items"),
+            totalQuestions=output.get("totalQuestions"),
+            formResponseId=output.get("formResponseId", ""),
+            totalScore=output.get("totalScore"),
+            totalPoints=output.get("totalPoints"),
+            status=output.get("status", ""),
+        )
+        return vo.FormProgressResponseVO(progress=progress)
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("check_form_progress error: %s", e)
+        return vo.FormProgressResponseVO(error="Facing internal error")
+
+
+@mcp.tool()
+async def create_form_response(
+    form_id: str,
+    user_id: str,
+    assign_id: str,
+    ctx: Context | None = None,
+) -> vo.CreateFormResponseResponseVO:
+    """
+    Create a form response id for the given form, user, and assignment.the returned response ID is used to save the form response.
+
+    Args:
+        form_id: The form id.
+        user_id: The user id (e.g. from get_current_user).
+        assign_id: The form assignment id (id from list_forms_assigned_to_me).
+
+    Returns:
+        - form_response (Optional[CreateFormResponseResultVO]): id (the new form response id).
+        - error (Optional[str]): Error message if the request failed.
+    """
+    try:
+        logger.info(
+            "create_form_response: form_id=%s, user_id=%s, assign_id=%s",
+            form_id,
+            user_id,
+            assign_id,
+        )
+
+        url = f"{constants.URL_FORMS}/{form_id}/responses"
+        payload = {"formId": form_id, "userId": user_id, "assignId": assign_id}
+        output = await utils.make_API_call_to_CCow_and_get_response(
+            url, "POST", payload, ctx=ctx
+        )
+        logger.debug("create_form_response output: %s", output)
+
+        if isinstance(output, str):
+            logger.error("create_form_response error: %s", output)
+            return vo.CreateFormResponseResponseVO(
+                error=output or "Facing internal error"
+            )
+        if isinstance(output, dict) and output.get("error"):
+            return vo.CreateFormResponseResponseVO(
+                error=output.get("error", "Facing internal error")
+            )
+        if isinstance(output, dict) and "Message" in output:
+            return vo.CreateFormResponseResponseVO(
+                error=output.get("Description") or output.get("Message", "Request failed")
+            )
+
+        if not isinstance(output, dict):
+            return vo.CreateFormResponseResponseVO(error="Invalid response")
+
+        form_response = vo.CreateFormResponseResultVO(
+            id=output.get("_id", ""),
+        )
+        return vo.CreateFormResponseResponseVO(form_response=form_response)
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("create_form_response error: %s", e)
+        return vo.CreateFormResponseResponseVO(error="Facing internal error")
+
+
+@mcp.tool()
+async def get_current_user(ctx: Context | None = None) -> vo.CurrentUserResponseVO:
+    """
+    Get the current authenticated user (id, email, username).
+    Use when creating form responses or when the flow needs the current user id.
+
+    Returns:
+        - user (Optional[CurrentUserVO]): ID, emailid, username.
+        - error (Optional[str]): Error message if the request failed.
+    """
+    try:
+        logger.info("get_current_user")
+
+        output = await utils.make_API_call_to_CCow_and_get_response(
+            constants.URL_USERS_ME, "GET", ctx=ctx
+        )
+        logger.debug("get_current_user output: %s", output)
+
+        if isinstance(output, str):
+            logger.error("get_current_user error: %s", output)
+            return vo.CurrentUserResponseVO(error=output or "Facing internal error")
+        if isinstance(output, dict) and output.get("error"):
+            return vo.CurrentUserResponseVO(
+                error=output.get("error", "Facing internal error")
+            )
+        if isinstance(output, dict) and "Message" in output:
+            return vo.CurrentUserResponseVO(
+                error=output.get("Description") or output.get("Message", "Request failed")
+            )
+
+        if not isinstance(output, dict):
+            return vo.CurrentUserResponseVO(error="Invalid response")
+
+        user = vo.CurrentUserVO(
+            ID=output.get("ID", ""),
+            emailid=output.get("emailid", ""),
+            username=output.get("username", ""),
+        )
+        return vo.CurrentUserResponseVO(user=user)
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("get_current_user error: %s", e)
+        return vo.CurrentUserResponseVO(error="Facing internal error")
+
+
+@mcp.tool()
+async def save_form_responses(
+    form_id: str,
+    form_response_id: str,
+    form_responses: Dict[str, Any],
+    ctx: Context | None = None,
+) -> vo.SaveFormResponsesResponseVO:
+    """
+    Save the state of the form. Sends element answers for the given form response.
+    Call this to persist answers before submitting.
+
+    Args:
+        form_id: The form id.
+        form_response_id: The form response id (from create_form_response).
+        form_responses: Map of element id -> answer value.
+            - String value for text/date answers. For option-type questions, pass the string index of the selected option (Radio Button, Checkbox, Dropdown).
+            - Date Range object: {toDate, fromDate}.
+            - File Upload value: list of objects with {bucketName, filePath, fileName, fileHash}.
+
+    Returns:
+        - success (bool): True if save succeeded (204).
+        - error (Optional[str]): Error message if the request failed.
+    """
+    try:
+        logger.info(
+            "save_form_responses: form_id=%s, form_response_id=%s",
+            form_id,
+            form_response_id,
+        )
+
+        url = f"{constants.URL_FORMS}/{form_id}/responses/{form_response_id}/elements"
+        payload = {
+            "formResponseId": form_response_id,
+            "formResponses": form_responses,
+        }
+        output = await utils.make_API_call_to_CCow_and_get_response(
+            url, "PUT", payload, ctx=ctx
+        )
+        logger.debug("save_form_responses output: %s", output)
+
+        if isinstance(output, str):
+            logger.error("save_form_responses error: %s", output)
+            return vo.SaveFormResponsesResponseVO(error=output or "Facing internal error")
+        if isinstance(output, dict) and output.get("error"):
+            return vo.SaveFormResponsesResponseVO(
+                error=output.get("error", "Facing internal error")
+            )
+        if isinstance(output, dict) and "Message" in output:
+            return vo.SaveFormResponsesResponseVO(
+                error=output.get("Description") or output.get("Message", "Request failed")
+            )
+
+        # 204 No Content returns {} from utils
+        return vo.SaveFormResponsesResponseVO(success=True)
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("save_form_responses error: %s", e)
+        return vo.SaveFormResponsesResponseVO(error="Facing internal error")
+
+
+@mcp.tool()
+async def submit_user_form(
+    user_id: str,
+    assign_id: str,
+    form_id: str,
+    ctx: Context | None = None,
+) -> vo.SubmitUserFormResponseVO:
+    """
+    Submit the form on behalf of the user. Call this after saving form responses when the user
+    is done filling the form.
+
+    Args:
+        user_id: The user id (e.g. from get_current_user).
+        assign_id: The form assignment id (id from list_forms_assigned_to_me).
+        form_id: The form id.
+
+    Returns:
+        - success (Optional[bool]): True if submit succeeded.
+        - error (Optional[str]): Error message if the request failed.
+    """
+    try:
+        logger.info(
+            "submit_user_form: user_id=%s, assign_id=%s, form_id=%s",
+            user_id,
+            assign_id,
+            form_id,
+        )
+
+        payload = {
+            "userID": user_id,
+            "myformID": assign_id,
+            "formID": form_id,
+        }
+        output = await utils.make_API_call_to_CCow_and_get_response(
+            constants.URL_USER_FORMS_SUBMIT, "POST", payload, ctx=ctx
+        )
+        logger.debug("submit_user_form output: %s", output)
+
+        if isinstance(output, str):
+            logger.error("submit_user_form error: %s", output)
+            return vo.SubmitUserFormResponseVO(
+                error=output or "Facing internal error"
+            )
+        if isinstance(output, dict) and output.get("error"):
+            return vo.SubmitUserFormResponseVO(
+                error=output.get("error", "Facing internal error")
+            )
+        if isinstance(output, dict) and "Message" in output:
+            return vo.SubmitUserFormResponseVO(
+                error=output.get("Description") or output.get("Message", "Request failed")
+            )
+
+        return vo.SubmitUserFormResponseVO(success=True)
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("submit_user_form error: %s", e)
+        return vo.SubmitUserFormResponseVO(error="Facing internal error")
+
+


### PR DESCRIPTION
Add MCP tools for form creation and submission

Form creation tools:
- `list_forms`
- `create_form`
- `update_form`
- `list_dynamic_options`
- `fetch_dynamic_option`

Form submission tools:
- `list_forms_assigned_to_me`
- `fetch_complete_form`
- `check_form_progress`
- `create_form_response`
- `save_form_responses`
- `submit_user_form`
- `get_current_user`
