### PR TITLE
Update form MCP

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,6 @@ import traceback
 
 from constants.constants import host
 from mcpconfig.config import mcp
-from tools.forms import forms
 from tools.general import general
 from utils.auth import CCowOAuthProvider
 from utils.debug import logger

--- a/prompts/forms/form_knowledge.md
+++ b/prompts/forms/form_knowledge.md
@@ -1,12 +1,10 @@
-FORM OVERVIEW
-=================
- A form in complianceow is a tool that collects structured inputs using question types.
+# FORM OVERVIEWS
 
- A form is primarily used for conducting surveys, feedback, and security/compliance questionnaires.
+## What is a form
+A form in ComplianceCow is a tool that collects structured inputs using question types.
+A form is primarily used for conducting surveys, feedback, and security/compliance questionnaires.
 
-------------------------------------------------------------
-QUESTIONS
---------------
+## Questions
 A question is the atomic building block of a form.
 
 Each question has:
@@ -14,117 +12,149 @@ Each question has:
 - a question type (how input is captured)
 - optional helper text (footer)
 - requiredness
-- an order position index (sequence)
+- an order position index (`sequence`; see below)
 - additional behavior that depends on the question type (for example: containers, grids, option-jumps, scoring)
 
-------------------------------------------------------------
-QUESTION TYPES
---------------
+## Sequence (order index)
+`sequence` is the **zero-based index of an element within its parent's `elements` array** -- it marks that element's position among its siblings at that level only.
+
+- At the top level of a form, each root question/section is listed in `elements` in order; each has `sequence` `0`, `1`, `2`, ... matching its position in that list.
+- **Nested containers** (for example a `Block` with child questions): the children have their **own** `elements` list, and each child's `sequence` is `0`, `1`, `2`, ... **within that nested list**, not the global form index. So numbering restarts under each parent.
+
+Example (structure only):
+
+```text
+elements: [
+  { sequence: 0 },
+  { sequence: 1, elements: [ { sequence: 0 }, ... ] },
+  { sequence: 2 }
+]
+```
+
+Here the outer array has three siblings at positions `0`, `1`, and `2`. The middle item's nested `elements` start again at `sequence: 0` for the first child inside that block.
+
+Jump logic (for example `nextInSequence` targeting a question) refers to the **configured sequence value** of a question in the form definition, which must stay consistent with this ordering when you add, remove, or reorder items.
+
+## Question types
 Forms support the following question types. Use the appropriate type based on the kind of input or content you need.
 
-1. BLOCK
--------------
-Definition:
-A structural container or section used to group related questions or content. Does not collect a direct answer, It may holds child question types.
+1. **Block** -- A structural container or section used to group related questions or content. Does not collect a direct answer. It may hold child question types.
 
-2. STATEMENT BLOCK
--------------
-Definition:
-A block that displays static text, instructions, or statements. Used to provide context or guidance without requiring user input.
+2. **Statement Block** -- A block that displays static text, instructions, or statements. Used to provide context or guidance without requiring user input.
 
-3. SHORT TEXT
--------------
-Definition:
-Single-line free text input. Accepts a short string (e.g. name, ID, code, single phrase).
+3. **Short Text** -- Single-line free text input. Accepts a short string (e.g. name, ID, code, single phrase).
 
-4. PARAGRAPH
--------------
-Definition:
-Multi-line free text input. Accepts longer prose, descriptions, or comments.
+4. **Paragraph** -- Multi-line free text input. Accepts longer prose, descriptions, or comments.
 
-5. RADIO BUTTON
--------------
-Definition:
-Single-choice selection from a fixed list of options. Only one option can be selected.
+5. **Radio Button** -- Single-choice selection from a fixed list of options. Only one option can be selected.
 
+6. **Checkbox** -- Multi-choice selection from a fixed list. One or more options can be selected.
 
-6. CHECKBOX
--------------
-Definition:
-Multi-choice selection from a fixed list. One or more options can be selected.
+7. **Dropdown** -- Single-choice selection from a list presented in a dropdown menu. Compact alternative to radio when many options exist. Also supports write-in input when write-in is enabled.
 
-7. DROPDOWN
--------------
-Definition:
-Single-choice selection from a list presented in a dropdown menu. Compact alternative to radio when many options exist. Also supports write-in input when write-in is enabled.
+8. **File Upload** -- Control that allows the respondent to attach or upload one or more files (e.g. documents, images).
 
+9. **Matrix** -- A grid-like container where each row is an answerable sub-question.
+   - Row question type is restricted: every row must be either `Radio Button` or `Checkbox` only (one type per matrix; do not mix).
+   - All rows in a Matrix must have the **same option set** (same order and meaning; point values apply consistently for quiz scoring).
+   - Use a Matrix when the form needs to capture the **same set of options** for multiple, related items.
+   - **Compliance example (radio)**: quarterly access certification where an approver must `Approve` / `Revoke` each user's role across a list of applications.
+   - **Security posture example (checkbox)**: periodic privilege review where a security admin selects which entitlements (e.g. `Read`, `Write`, `Admin`) should remain for each service account.
 
-8. FILE UPLOAD
--------------
-Definition:
-Control that allows the respondent to attach or upload one or more files (e.g. documents, images).
+10. **Date** -- Single date picker. Captures a calendar date (day, month, year), the date format is MM/DD/YYYY.
 
-9. MATRIX
--------------
-- A matrix is a grid-like container where each row is an answerable sub-question.
-- Row question type is restricted: every row must be either `Radio Button` or `Checkbox` only (one type per matrix; do not mix).
-- All rows in a Matrix must have the **same option set** (same order and meaning; point values apply consistently for quiz scoring).
+11. **Date Range** -- Start and end date pickers. Captures a period (e.g. project duration, validity window), the date format is MM/DD/YYYY.
 
-When to use Matrix question type:
-- Use a Matrix when the form needs to capture the **same set of options** for multiple, related items, using either `Radio Button` or `Checkbox`.
-- **Compliance example (radio)**: quarterly access certification where an approver must `Approve` / `Revoke` each user’s role across a list of applications.
-- **Security posture example (checkbox)**: periodic privilege review where a security admin selects which entitlements (e.g. `Read`, `Write`, `Admin`) should remain for each service account.
+## Form category
+A **form category** is a label that groups related forms together. There is no separate category object in the API: the category **name** is stored as a form-level tag.
 
-10. DATE
--------------
-Definition: 
-Single date picker. Captures a calendar date (day, month, year), the date format is MM/DD/YYYY.
+- Add a tag on the form with **`key`: `form_category`**. The **`values`** array holds the category name (for example `["Compliance"]`).
+- At least **one** form must use this tag for a given category name before that category can appear when listing categories (categories are **derived** from tags, not created empty).
+- Tag shape (example):
 
-11. DATE RANGE
--------------
-Definition:
-Start and end date pickers. Captures a period (e.g. project duration, validity window), the date format is MM/DD/YYYY.
+```json
+[
+  {
+    "key": "form_category",
+    "index": 0,
+    "primary": true,
+    "values": ["Compliance"]
+  }
+]
+```
 
-------------------------------------------------------------
-FORM CREATION RULES
---------------------
+Use the MCP tools `list_form_categories`, `fetch_form_category`, and `set_form_category` to list category names, list forms in a category, or assign/update the `form_category` tag on a form.
 
-Dynamic options
---------------
+## Form assignment
+- A form can be assigned to any set of valid users.
+- Upon assigning a form, you can also set `dueDate` and provide a `purpose` for that form assignment.
+
+## Form configuration (optional, UI specific)
+Form configuration customizes how a form is rendered in UI (look and feel + display behavior). It does not change question semantics or response meaning.
+
+- Available global configuration catalogs include:
+  - style catalogs: `fontFamilies`, `fontSizes`, `colors`, `layouts`
+  - display-behavior catalog: `settings`
+- A form-level `configuration` object can be added or updated after form creation, and can also be updated later for already-assigned forms.
+- `configuration` is optional and is stored on the form under the `configuration` key.
+- `configuration.display` holds settings values as string booleans (`"true"` / `"false"`), e.g. `showPagination`, `showOneByOne`, `showQuestionProgress`, `showQuestionNumber`.
+- `configuration.styles` holds visual style selections:
+  - `typography`: `font`, `fontSize`, `fontColor`
+    - `fontColor` must be the `cssVar` from the colors config options (e.g. `"--color-destructive-400"`), not the hex value. Show the color `label` to the user; save the `cssVar`.
+  - `layout`: `value`, `spacing`, `width`, `lineHeight`
+
+Example:
+```json
+{
+  "configuration": {
+    "display": {
+      "showPagination": "true",
+      "showOneByOne": "false",
+      "showQuestionProgress": "false",
+      "showQuestionNumber": "false"
+    },
+    "styles": {
+      "typography": {
+        "font": "Inter, sans-serif",
+        "fontSize": 10,
+        "fontColor": "--color-constructive-100"
+      },
+      "layout": {
+        "value": "compact",
+        "spacing": 8,
+        "width": 750,
+        "lineHeight": 1.4
+      }
+    }
+  }
+}
+```
+
+## Form creation design concepts
+
+### Dynamic options
 - Dynamic options provide a reusable preset list of options for option-type questions (Radio Button, Checkbox, Dropdown).
 - Always include a static fallback options list. Dynamic options may be unavailable, but the form must remain usable.
 
-Jump configuration
---------------
+### Jump configuration
 - Jump configuration redirects the next step based on the option selected.
-- Example: Jump configuration reference (design-time)
-  - Question configuration indicates that options may contain jump directives.
-  - At runtime, each option’s directive is interpreted as:
-    - `nextInSequence: -2` => jump directly to submission
-    - `nextInSequence: -3` => treat as “no jump”; follow default traversal order
-    - `nextInSequence: <n>` => jump to the question whose configured sequence matches `<n>`
+- Question configuration indicates that options may contain jump directives.
+- At runtime, each option's directive is interpreted as:
+  - `nextInSequence: -2` => jump directly to submission
+  - `nextInSequence: -3` => treat as "no jump"; follow default traversal order
+  - `nextInSequence: <n>` => jump to the question whose configured sequence matches `<n>`
 
-Enable write in
---------------
+### Write-in
 - Write-in is supported only for `Dropdown` questions.
 - When write-in is enabled, the respondent can choose an option or enter a custom value.
+- Enable with `isWriteInEnabled: true`.
 
-Example: Write-in flag (design-time)
-- `isWriteInEnabled: true`
-
-Form quiz
---------------
+### Quiz mode
 - Quiz/scoring mode enables point-based scoring for option selections.
 - When quiz mode is enabled, each option should define its point value.
+- Enable with `isQuiz: true`; each option includes `points`.
 
-Example: Quiz/scoring mode (design-time)
-- `isQuiz: true`
-- Each option includes `points`
-
-
-
-Example: Single question payload (Radio Button, design-time)
----------------------------------------------------------------
+### Example question payload (Radio Button, design-time)
 Use this structure when defining a Radio Button question inside a form. Placeholders are values you set while creating the form.
 
 ```json
@@ -149,12 +179,12 @@ Use this structure when defining a Radio Button question inside a form. Placehol
 }
 ```
 
-Field meanings (placeholders)
+Field meanings (placeholders):
 - `type`: Question type. Use `"Radio Button"`.
 - `title`: Question label shown to the user (`{{question_title}}`).
 - `footer`: Helper text shown under the question (`{{question_footer}}`).
 - `isRequired`: Whether the user must answer (`{{is_required}}`).
-- `sequence`: Ordering position index within the form (zero based indexing sequence)(`{{sequence_index}}`).
+- `sequence`: Zero-based index of this element within its parent's `elements` array (sibling order at that level; nested lists each start at `0` again) (`{{sequence_index}}`).
 - `tags`: Optional metadata list (`{{tag_value_1}}`, `{{tag_value_2}}`).
 - `points`: Maximum points for quiz scoring (`{{question_points_max}}`).
 - `nextInSequence`: Question-level jump configuration flag (`{{question_level_jump_flag}}`).
@@ -165,25 +195,27 @@ Field meanings (placeholders)
   - `defaultChecked`: Whether this option is pre-selected (`{{default_checked}}`).
   - `nextInSequence`: Option-level navigation directive (`{{option_level_jump_directive}}`).
 
-OPERATIONAL RULES FOR FORM CREATION / UPDATES
-------------------------------------------------
+# OPERATIONAL RULES
+
+## Form creation and update guardrails
 - Before creating or changing a form, prepare a plan (purpose, question types, order, scoring/jump logic) and ask for explicit user confirmation.
 - After creating a form, show the form name and form id; keep the form id for later modifications.
 - When modifying an existing form, update that form instead of creating a new one.
-- If the request to “update/change the form” is ambiguous, ask which form to modify (by name or by id) or use the form id from the current conversation.
-- If the requirement is vague (e.g. “add some questions”, “make a survey”), do not guess: ask the minimum clarifying question(s), one at a time; after each answer, acknowledge and continue.
+- If the request to "update/change the form" is ambiguous, ask which form to modify (by name or by id) or use the form id from the current conversation.
+- If the requirement is vague (e.g. "add some questions", "make a survey"), do not guess: ask the minimum clarifying question(s), one at a time; after each answer, acknowledge and continue.
 - Use only question types and structures documented in this file.
 - For `Radio Button`, `Checkbox`, and `Dropdown`, always provide options; use dynamic options only when intended; keep sequence consistent when adding/reordering.
 - For `Matrix`, ensure every child row uses the same option set; when you change an option label/meaning in one row, apply it to all rows in that matrix.
+- Once form is created ask the user to verify the form by showing a link to the created form `host+/ui/manage-forms?id={{form_id}}`.
+- After form creation optionally ask user for form configuration preferences.
 
-FORM SUBMISSION RULES 
------------------------
+## Form submission behavior
 
-PRE-SUBMISSION CONFIRMATION RULE
-- Before final submission, show a human-readable summary of what the user filled so far.
+### Pre-submission confirmation
+- Before final submission, show a human-readable summary of what the user filled so far and a link to preview filled form `host+/ui/display-form?assign_id={{form_assign_id}}`.
 - Proceed with submission ONLY after the user explicitly confirms.
 
-RESUME / START-OVER RULE
+### Resume / start-over
 - Load the saved progress for the current form and assignment.
 - If no answers have been saved yet:
   - Start collecting from the first answerable question in traversal order.
@@ -196,59 +228,58 @@ RESUME / START-OVER RULE
     - Start from the first answerable question again.
     - Overwrite previously saved answers as the user re-enters them.
 
-TRAVERSAL RULES (STRUCTURE)
+### Traversal rules
 - `Block` and `Statement Block`:
   - Do not ask for a direct answer.
   - Recursively traverse nested questions in declared order.
 - `Matrix`:
   - Treat each child row question as answerable.
-  - Collect each row’s answer in increasing order.
+  - Collect each row's answer in increasing order.
 
-INPUT COLLECTION RULES (ONE QUESTION AT A TIME)
+### Input collection rules (one question at a time)
 - Ask exactly one question per step.
-- QUIZ CONFIDENTIALITY RULE
-  - If the form is in quiz mode, do not reveal any answers while collecting:
-    - do not show the correct option(s)/answer key
-    - do not provide correctness feedback or scoring before submission
+- Quiz confidentiality: if the form is in quiz mode, do not reveal any answers while collecting; do not show the correct option(s)/answer key; do not provide correctness feedback or scoring before submission.
 - After the user answers a question:
   - Persist ONLY that single answer into the current in-progress response mapping.
-  - Update the local “answered set” so navigation decisions are correct.
+  - Update the local "answered set" so navigation decisions are correct.
 - Do not batch multiple question answers in a single step.
 
-NEXT-QUESTION SELECTION RULE (JUMP LOGIC)
+### Next-question selection (jump logic)
 - Default: always follow traversal order to the next answerable question.
 - Jump logic applies only to option-type questions: `Radio Button` and `Dropdown`.
 - When jump directives are enabled for the selected option:
-  - If the directive indicates “jump to submission”, end the traversal and submit.
-  - If the directive indicates “no jump”, fall back to default traversal order.
+  - If the directive indicates "jump to submission", end the traversal and submit.
+  - If the directive indicates "no jump", fall back to default traversal order.
   - Otherwise, jump to the question whose configured sequence/order matches the directive target.
 
-FILE UPLOAD RULE
+### File upload behavior
 - Never request raw file bytes inside chat.
 - For the current `File Upload` question:
-  - Provide the user the UI upload URL:
-    - `host+"/ui/display-form?assign_id={{assign_id}}"`
+  - Provide the user the UI upload URL: `host+"/ui/display-form?assign_id={{assign_id}}"`.
   - Ask the user to complete the upload in the UI.
   - After upload completion is confirmed by the user:
     - Reload saved progress.
     - Proceed only once the saved answer for this upload question is available.
 
-SUBMIT RULE
+### Final submit behavior
 - When traversal ends (or jump indicates submission):
-  - Build a human-readable summary using the form’s question labels and the user’s saved selections.
+  - Build a human-readable summary using the form's question labels and the user's saved selections.
   - Show the summary and request explicit confirmation.
   - If confirmed: submit the form for the current user + assignment.
   - If declined: ask whether to `continue editing` (resume) or `start over`.
 
-EXAMPLES (wire-format only; keep these details out of normal explanations)
+## Form assignment behavior
+- First, ask for a list of user emails or user groups to assign the form to.
+- Once collected, convert the emails to the corresponding user IDs and validate the user IDs.
+- Assign the form to the valid user IDs and return a summary of the assignments to the users (including any failures, if available).
+
+## Wire-format operational references
 - Saved progress view:
   - `progress.items`: mapping of answered `element_id` -> stored answer
   - `progress.formResponseId`: the saved response/session identifier used while saving answers
 - Option answer encoding:
-  - For option-type questions, persist the selected option’s configured `value` (string index/value), not the label.
+  - For option-type questions, persist the selected option's configured `value` (string index/value), not the label.
 - Jump directive reference (runtime interpretation):
   - `nextInSequence: -2` => jump to submission
   - `nextInSequence: -3` => no jump; use default traversal
   - `nextInSequence: <n>` => jump to question sequence/order `<n>`
-
- 

--- a/tools/forms/forms.py
+++ b/tools/forms/forms.py
@@ -1,7 +1,5 @@
-
-import copy
 import traceback
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from fastmcp import Context
 
@@ -10,28 +8,22 @@ from mcpconfig.config import mcp
 from mcptypes import forms_tool_types as vo
 from utils import utils
 from utils.debug import logger
-
-
-def _normalize_matrix_options(elements: List[Any]) -> None:
-    """For each Matrix element, sync all children's options to the first child's options (mutates in place). Recurses into Block/Statement Block/Matrix."""
-    if not elements:
-        return
-    for item in elements:
-        if not isinstance(item, dict):
-            continue
-        child_elements = item.get("elements")
-        if isinstance(child_elements, list):
-            if item.get("type") == "Matrix" and len(child_elements) > 0:
-                first_options = child_elements[0].get("options")
-                if first_options is not None:
-                    first_options_copy = copy.deepcopy(first_options)
-                    for child in child_elements[1:]:
-                        if isinstance(child, dict) and child.get("type") in (
-                            "Radio Button",
-                            "Checkbox",
-                        ):
-                            child["options"] = copy.deepcopy(first_options_copy)
-            _normalize_matrix_options(child_elements)
+from utils.forms import (
+    collect_assignable_element_ids,
+    elements_from_raw,
+    extract_assign_form_ids_and_error,
+    fetch_form_elements_for_assignment,
+    fetch_form_raw,
+    form_category_values,
+    is_form_assigned,
+    is_dynamic_option_active,
+    list_forms_impl,
+    merge_form_category_tag,
+    normalize_assign_form_inputs,
+    normalize_matrix_options,
+    parse_form_tags_from_raw,
+    update_form_impl,
+)
 
 
 @mcp.tool()
@@ -43,31 +35,54 @@ async def list_forms(ctx: Context | None = None) -> vo.FormListVO:
             - forms (List[FormVO]): A list of forms. Each form has:
                 - id (str): Form id.
                 - name (str): Form name.
+                - tags (Optional[List[FormTagsItemVO]]): Form-level tags when the list API returns them (e.g. key form_category). Category tools require tags on each item from GET /v1/forms.
             - error (Optional[str]): An error message if any issues occurred during retrieval.
     """
+    return await list_forms_impl(ctx)
+
+
+@mcp.tool()
+async def get_configurations_for_forms(
+    ctx: Context | None = None,
+) -> vo.GetFormConfigurationsResponseVO:
+    """
+    Get all form configuration options available globally for UI customization.
+
+    Returns:
+        - configurations (Optional[FormConfigurationsVO]): Catalog with fontFamilies, fontSizes, colors, layouts, settings.
+        - error (Optional[str]): Error message if the request failed.
+    """
     try:
-        logger.info("list_forms: \n")
+        logger.info("get_configurations_for_forms")
 
-        output = await utils.make_API_call_to_CCow_and_get_response(constants.URL_FORMS, "GET", ctx)
-        logger.debug("list_forms output: {}\n".format(output))
-        if isinstance(output, str) or "error" in output:
-            logger.error("list_forms error: {}\n".format(output))
-            return vo.FormListVO(error="Facing internal error")
+        output = await utils.make_API_call_to_CCow_and_get_response(
+            constants.URL_FORMS_CONFIGURATIONS, "GET", ctx=ctx
+        )
+        logger.debug("get_configurations_for_forms output: %s", output)
 
-        forms: List[vo.FormVO] = []
-        for item in output:
-            forms.append(
-                vo.FormVO(
-                    id=item.get("_id", ""),
-                    name=item.get("name", ""),
-                )
+        if isinstance(output, str):
+            logger.error("get_configurations_for_forms error: %s", output)
+            return vo.GetFormConfigurationsResponseVO(
+                error=output or "Facing internal error"
             )
+        if isinstance(output, dict) and output.get("error"):
+            return vo.GetFormConfigurationsResponseVO(
+                error=output.get("error", "Facing internal error")
+            )
+        if isinstance(output, dict) and "Message" in output:
+            return vo.GetFormConfigurationsResponseVO(
+                error=output.get("Description") or output.get("Message", "Request failed")
+            )
+        if not isinstance(output, dict):
+            return vo.GetFormConfigurationsResponseVO(error="Invalid response")
 
-        return vo.FormListVO(forms=forms)
+        return vo.GetFormConfigurationsResponseVO(
+            configurations=vo.FormConfigurationsVO(**output)
+        )
     except Exception as e:
         logger.error(traceback.format_exc())
-        logger.error("list_forms error: {}\n".format(e))
-        return vo.FormListVO(error="Facing internal error")
+        logger.error("get_configurations_for_forms error: %s", e)
+        return vo.GetFormConfigurationsResponseVO(error="Facing internal error")
 
 @mcp.tool()
 async def create_form(form: vo.CreateFormVO, ctx: Context | None = None) -> vo.CreateFormResponseVO:
@@ -106,9 +121,9 @@ async def create_form(form: vo.CreateFormVO, ctx: Context | None = None) -> vo.C
     try:
         logger.info("create_form: name=%s", form.name or form.title)
 
-        payload = form.to_payload()
+        payload = form.to_api_payload()
         if payload.get("elements"):
-            _normalize_matrix_options(payload["elements"])
+            normalize_matrix_options(payload["elements"])
         output = await utils.make_API_call_to_CCow_and_get_response(
             constants.URL_FORMS, "POST", payload, ctx=ctx
         )
@@ -125,7 +140,6 @@ async def create_form(form: vo.CreateFormVO, ctx: Context | None = None) -> vo.C
                 error=output.get("Description") or output.get("Message", "Request failed")
             )
 
-        # Success: response may be the created form object (e.g. _id, name)
         created = output if isinstance(output, dict) else {}
         form_id = created.get("_id") or created.get("id", "")
         form_name = created.get("name") or created.get("title", "")
@@ -140,6 +154,95 @@ async def create_form(form: vo.CreateFormVO, ctx: Context | None = None) -> vo.C
 
 
 @mcp.tool()
+async def clone_form(
+    form_id: str,
+    form_clone_name: str,
+    ctx: Context | None = None,
+) -> vo.CreateFormResponseVO:
+    """
+    Clone an existing form using a new form name.
+
+    Args:
+        form_id: Source form ID to clone.
+        form_clone_name: Name for the cloned form.
+
+    Returns:
+        - form (Optional[FormVO]): Cloned form with id and name.
+        - error (Optional[str]): Error message if cloning failed.
+    """
+    try:
+        logger.info("clone_form: form_id=%s, clone_name=%s", form_id, form_clone_name)
+
+        clone_name = form_clone_name.strip()
+        if not clone_name:
+            return vo.CreateFormResponseVO(error="form_clone_name is required")
+
+        raw = await fetch_form_raw(form_id, ctx)
+        if isinstance(raw, str):
+            return vo.CreateFormResponseVO(error=raw)
+        if not isinstance(raw, dict):
+            return vo.CreateFormResponseVO(error="Invalid source form response")
+
+        source_tags = raw.get("tags")
+        tag_items: List[vo.FormTagVO] = []
+        if isinstance(source_tags, list):
+            for t in source_tags:
+                if not isinstance(t, dict):
+                    continue
+                idx = t.get("index")
+                prim = t.get("primary")
+                vals = t.get("values")
+                tag_items.append(
+                    vo.FormTagVO(
+                        index=idx if isinstance(idx, int) else 0,
+                        key=t.get("key", "") or "",
+                        primary=prim if isinstance(prim, bool) else False,
+                        values=vals if isinstance(vals, list) else [],
+                    )
+                )
+
+        clone_vo = vo.CreateFormVO(
+            name=clone_name,
+            title=clone_name,
+            elements=raw.get("elements") if isinstance(raw.get("elements"), list) else [],
+            type=raw.get("type", "") or "",
+            tag=tag_items,
+            isQuiz=raw.get("isQuiz", False),
+            totalPoints=raw.get("totalPoints", 0),
+            configuration=raw.get("configuration"),
+        )
+
+        payload = clone_vo.to_api_payload()
+        if payload.get("elements"):
+            normalize_matrix_options(payload["elements"])
+
+        output = await utils.make_API_call_to_CCow_and_get_response(
+            constants.URL_FORMS, "POST", payload, ctx=ctx
+        )
+        logger.debug("clone_form output: %s", output)
+
+        if isinstance(output, str):
+            return vo.CreateFormResponseVO(error=output or "Facing internal error")
+        if isinstance(output, dict) and output.get("error"):
+            return vo.CreateFormResponseVO(
+                error=output.get("error", "Facing internal error")
+            )
+        if isinstance(output, dict) and "Message" in output:
+            return vo.CreateFormResponseVO(
+                error=output.get("Description") or output.get("Message", "Request failed")
+            )
+
+        created = output if isinstance(output, dict) else {}
+        created_id = created.get("_id") or created.get("id", "")
+        created_name = created.get("name") or created.get("title", "")
+        return vo.CreateFormResponseVO(form=vo.FormVO(id=created_id, name=created_name))
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("clone_form error: %s", e)
+        return vo.CreateFormResponseVO(error="Facing internal error")
+
+
+@mcp.tool()
 async def update_form(
     form_id: str,
     form: vo.UpdateFormVO,
@@ -147,8 +250,6 @@ async def update_form(
 ) -> vo.UpdateFormResponseVO:
     """
     Update an existing form.
-
-    This function is used to update an existing form using form id and payload.
 
     Args:
         form_id: Form ID to update.
@@ -182,50 +283,226 @@ async def update_form(
         - form (Optional[FormVO]): Updated form with id and name (from request; API returns no body).
         - error (Optional[str]): Error message if update failed.
     """
-    try:
-        logger.info("update_form: form_id=%s", form_id)
-
-        url = f"{constants.URL_FORMS}/{form_id}"
-        payload = form.to_payload()
-        if payload.get("elements"):
-            _normalize_matrix_options(payload["elements"])
-        output = await utils.make_API_call_to_CCow_and_get_response(
-            url, "PUT", payload, ctx=ctx
-        )
-        logger.debug("update_form output: %s", output)
-
-        if isinstance(output, str):
-            logger.error("update_form error: %s", output)
-            return vo.UpdateFormResponseVO(error=output or "Facing internal error")
-        if isinstance(output, dict) and output.get("error"):
-            logger.error("update_form error: %s", output)
-            return vo.UpdateFormResponseVO(
-                error=output.get("error", "Facing internal error")
-            )
-        if isinstance(output, dict) and "Message" in output:
-            return vo.UpdateFormResponseVO(
-                error=output.get("Description") or output.get("Message", "Request failed")
-            )
-
+    assigned_state = await is_form_assigned(form_id, ctx)
+    if isinstance(assigned_state, str):
+        return vo.UpdateFormResponseVO(error=assigned_state)
+    if assigned_state is True:
         return vo.UpdateFormResponseVO(
-            form=vo.FormVO(
-                id=form_id,
-                name=form.name or form.title or "",
-            )
+            error="This form is already assigned and cannot be edited."
+        )
+    return await update_form_impl(form_id, form, ctx)
+
+
+@mcp.tool()
+async def update_form_configuration(
+    form_id: str,
+    config: vo.FormConfigurationVO,
+    ctx: Context | None = None,
+) -> vo.UpdateFormConfigurationResponseVO:
+    """
+    Update a form's UI-only configuration (display/styles).
+
+    Args:
+        form_id: Form ID to update.
+        config: UI configuration payload to save under form `configuration`.
+            - config.styles.typography.fontColor: must be the `cssVar` from the colors
+              configuration options (e.g. "--color-destructive-400"), not the hex `value`.
+
+    Returns:
+        - form (Optional[FormVO]): Updated form id/name.
+        - configuration (Optional[FormConfigurationVO]): Saved configuration.
+        - message (Optional[str]): Success message.
+        - error (Optional[str]): Error message if update failed.
+    """
+    try:
+        logger.info("update_form_configuration: form_id=%s", form_id)
+
+        raw = await fetch_form_raw(form_id, ctx)
+        if isinstance(raw, str):
+            return vo.UpdateFormConfigurationResponseVO(error=raw)
+        if not isinstance(raw, dict):
+            return vo.UpdateFormConfigurationResponseVO(error="Invalid form response")
+
+        elements = elements_from_raw(raw.get("elements"))
+        if elements is None:
+            elements = []
+        tags = parse_form_tags_from_raw(raw.get("tags"))
+
+        uf = vo.UpdateFormVO(
+            name=raw.get("name", "") or "",
+            title=raw.get("title"),
+            isQuiz=raw.get("isQuiz", False),
+            totalPoints=raw.get("totalPoints", 0),
+            elements=elements,
+            type=raw.get("type", "") or "",
+            tags=tags,
+            configuration=config,
+        )
+
+        updated = await update_form_impl(form_id, uf, ctx=ctx)
+        if updated.error:
+            return vo.UpdateFormConfigurationResponseVO(error=updated.error)
+
+        return vo.UpdateFormConfigurationResponseVO(
+            form=vo.FormVO(id=form_id, name=uf.name),
+            configuration=config,
+            message="Form configuration updated.",
         )
     except Exception as e:
         logger.error(traceback.format_exc())
-        logger.error("update_form error: %s", e)
-        return vo.UpdateFormResponseVO(error="Facing internal error")
+        logger.error("update_form_configuration error: %s", e)
+        return vo.UpdateFormConfigurationResponseVO(error="Facing internal error")
 
 
-def _is_dynamic_option_active(status) -> bool:
-    """True if status indicates active dynamic option"""
-    if status is True:
-        return True
-    if isinstance(status, str) and str(status).lower() == "active":
-        return True
-    return False
+@mcp.tool()
+async def list_form_categories(ctx: Context | None = None) -> vo.FormCategoryListVO:
+    """
+    List distinct form category names derived from the form tag key `form_category`.
+
+    Uses a single GET /v1/forms (same as list_forms). Each form must include `tags` on the
+    list response for its category to appear; otherwise that form is skipped for category discovery.
+
+    Returns:
+        - categories (Optional[List[str]]): Sorted unique category values from all forms' `form_category` tags.
+        - error (Optional[str]): Error message if the request failed.
+    """
+    try:
+        logger.info("list_form_categories")
+        listed = await list_forms_impl(ctx=ctx)
+        if listed.error:
+            return vo.FormCategoryListVO(categories=[], error=listed.error)
+        seen: set[str] = set()
+        out: List[str] = []
+        for f in listed.forms or []:
+            for v in form_category_values(f.tags):
+                if v not in seen:
+                    seen.add(v)
+                    out.append(v)
+        out.sort()
+        return vo.FormCategoryListVO(categories=out)
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("list_form_categories error: %s", e)
+        return vo.FormCategoryListVO(error="Facing internal error")
+
+
+@mcp.tool()
+async def fetch_form_category(
+    category: str,
+    ctx: Context | None = None,
+) -> vo.FormCategoryMembersVO:
+    """
+    List forms that belong to a given category (exact match on a value in the `form_category` tag).
+
+    Uses a single GET /v1/forms. Requires `tags` on each list item to detect membership.
+
+    Args:
+        category: Category name to match exactly against tag values.
+
+    Returns:
+        - category (str): The requested category.
+        - forms (Optional[List[FormVO]]): Matching forms (id, name, tags when present).
+        - error (Optional[str]): Error message if the request failed.
+    """
+    try:
+        logger.info("fetch_form_category: category=%s", category)
+        listed = await list_forms_impl(ctx=ctx)
+        if listed.error:
+            return vo.FormCategoryMembersVO(category=category, error=listed.error)
+        matched: List[vo.FormVO] = []
+        for f in listed.forms or []:
+            vals = form_category_values(f.tags)
+            if category in vals:
+                matched.append(f)
+        return vo.FormCategoryMembersVO(category=category, forms=matched)
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("fetch_form_category error: %s", e)
+        return vo.FormCategoryMembersVO(category=category, error="Facing internal error")
+
+
+@mcp.tool()
+async def set_form_category(
+    form_name: str,
+    form_category: str,
+    ctx: Context | None = None,
+) -> vo.SetFormCategoryResponseVO:
+    """
+    Set or update the `form_category` tag on a form by form name.
+
+    Resolves the form via list_forms (GET /v1/forms), then loads the full definition with
+    POST /v1/forms/fetch (assignId empty) and PUT /v1/forms/{id} so elements are preserved.
+
+    Args:
+        form_name: Exact form name to update.
+        form_category: Category value to store (e.g. Compliance).
+
+    Returns:
+        - form (Optional[FormVO]): id, name, and merged tags on success.
+        - message (Optional[str]): Short success message.
+        - error (Optional[str]): Error message if resolution or update failed.
+    """
+    try:
+        logger.info("set_form_category: form_name=%s category=%s", form_name, form_category)
+        if not form_name.strip():
+            return vo.SetFormCategoryResponseVO(error="form_name is required")
+        if not form_category.strip():
+            return vo.SetFormCategoryResponseVO(error="form_category is required")
+
+        listed = await list_forms_impl(ctx=ctx)
+        if listed.error:
+            return vo.SetFormCategoryResponseVO(error=listed.error)
+        matches = [f for f in (listed.forms or []) if (f.name or "") == form_name]
+        if len(matches) == 0:
+            return vo.SetFormCategoryResponseVO(
+                error=f"No form found with name {form_name!r}."
+            )
+        if len(matches) > 1:
+            return vo.SetFormCategoryResponseVO(
+                error=f"Multiple forms match name {form_name!r}; resolve duplicates in the system."
+            )
+        form_id = matches[0].id or ""
+        if not form_id:
+            return vo.SetFormCategoryResponseVO(error="Form id missing for matched form.")
+
+        raw = await fetch_form_raw(form_id, ctx)
+        if isinstance(raw, str):
+            return vo.SetFormCategoryResponseVO(error=raw)
+
+        elements = elements_from_raw(raw.get("elements"))
+        if elements is None:
+            elements = []
+
+        existing_tags = parse_form_tags_from_raw(raw.get("tags"))
+        merged_tags = merge_form_category_tag(existing_tags, form_category.strip())
+
+        uf = vo.UpdateFormVO(
+            name=raw.get("name", "") or form_name,
+            title=raw.get("title"),
+            isQuiz=raw.get("isQuiz", False),
+            totalPoints=raw.get("totalPoints", 0),
+            elements=elements,
+            type=raw.get("type", "") or "",
+            tags=merged_tags,
+            configuration=raw.get("configuration"),
+        )
+
+        updated = await update_form_impl(form_id, uf, ctx=ctx)
+        if updated.error:
+            return vo.SetFormCategoryResponseVO(error=updated.error)
+
+        return vo.SetFormCategoryResponseVO(
+            form=vo.FormVO(
+                id=form_id,
+                name=uf.name or "",
+                tags=merged_tags,
+            ),
+            message="Form category updated.",
+        )
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("set_form_category error: %s", e)
+        return vo.SetFormCategoryResponseVO(error="Facing internal error")
 
 
 @mcp.tool()
@@ -263,7 +540,7 @@ async def list_dynamic_options(ctx: Context | None = None) -> vo.DynamicOptionLi
             if not isinstance(item, dict):
                 continue
             status = item.get("status")
-            if not _is_dynamic_option_active(status):
+            if not is_dynamic_option_active(status):
                 continue
             items.append(
                 vo.DynamicOptionVO(
@@ -318,7 +595,7 @@ async def fetch_dynamic_option(
             return vo.DynamicOptionDetailResponseVO(error="Invalid response")
 
         status = output.get("status")
-        if not _is_dynamic_option_active(status):
+        if not is_dynamic_option_active(status):
             return vo.DynamicOptionDetailResponseVO(
                 error="Dynamic option is not active; only active dynamic option sets can be used."
             )
@@ -457,17 +734,7 @@ async def fetch_complete_form(
                     except Exception:
                         pass
 
-        tags_raw = output.get("tags") or []
-        tags_list: List[vo.FormTagsItemVO] = []
-        if isinstance(tags_raw, list):
-            for t in tags_raw:
-                if isinstance(t, dict):
-                    tags_list.append(
-                        vo.FormTagsItemVO(
-                            key=t.get("key", ""),
-                            values=t.get("values") if t.get("values") is not None else [],
-                        )
-                    )
+        tags_list = parse_form_tags_from_raw(output.get("tags"))
 
         form_detail = vo.FormDetailVO(
             id=output.get("_id", ""),
@@ -476,7 +743,8 @@ async def fetch_complete_form(
             isQuiz=output.get("isQuiz", False),
             totalPoints=output.get("totalPoints", 0),
             type=output.get("type", ""),
-            tags=tags_list if tags_list else None,
+            tags=tags_list,
+            configuration=output.get("configuration"),
             elements=elements_list,
         )
         return vo.FormDetailResponseVO(form=form_detail)
@@ -765,5 +1033,273 @@ async def submit_user_form(
         logger.error(traceback.format_exc())
         logger.error("submit_user_form error: %s", e)
         return vo.SubmitUserFormResponseVO(error="Facing internal error")
+
+
+@mcp.tool()
+async def list_user_blocks(
+    ctx: Context | None = None,
+) -> list[vo.UserBlockVO] | str:
+    """
+    List active user blocks/groups.
+    Returns:
+        - List of items with:
+          - userBlockName
+          - userBlockDesc
+          - id
+          - users (list of user email ids)
+        - str on error
+    """
+    try:
+        logger.info("list_user_blocks")
+
+        payload = {"isStatusToBeIncluded": True, "state": "active"}
+        output = await utils.make_API_call_to_CCow_and_get_response(
+            constants.URL_USER_BLOCKS, "GET", payload, ctx=ctx
+        )
+        logger.debug("list_user_blocks output: %s", output)
+
+        if isinstance(output, str):
+            logger.error("list_user_blocks error: %s", output)
+            return output or "Facing internal error"
+
+        if not isinstance(output, dict):
+            return "Invalid response"
+
+        if output.get("error"):
+            return output.get("error", "Facing internal error")
+        if "Message" in output:
+            return output.get("Description") or output.get("Message", "Request failed")
+
+        items_raw = output.get("items", [])
+        if not isinstance(items_raw, list):
+            items_raw = []
+
+        result: list[vo.UserBlockVO] = []
+        for item in items_raw:
+            if not isinstance(item, dict):
+                continue
+
+            metadata = item.get("metadata", {})
+            if not isinstance(metadata, dict):
+                metadata = {}
+
+            status = item.get("status", {})
+            if not isinstance(status, dict):
+                status = {}
+
+            matching_users = status.get("matchingUsers", [])
+            if not isinstance(matching_users, list):
+                matching_users = []
+
+            result.append(
+                vo.UserBlockVO(
+                    userBlockName=metadata.get("name", "") or "",
+                    userBlockDesc=metadata.get("description", "") or "",
+                    id=item.get("id", "") or "",
+                    users=[str(u) for u in matching_users if u is not None],
+                )
+            )
+
+        return result
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("list_user_blocks error: %s", e)
+        return "Facing internal error"
+
+
+@mcp.tool()
+async def search_users_by_email_ids(
+    email_ids: List[str],
+    ctx: Context | None = None,
+) -> list[vo.UserSearchResultVO] | str:
+    """
+    Search users by email ids.
+    Args:
+        email_ids: List of email ids to search.
+
+    Returns:
+        - List of { id, username, emailId }
+        - str on error
+    """
+    try:
+        logger.info("search_users_by_email_ids")
+
+        normalized_emails = [e.strip() for e in email_ids if isinstance(e, str) and e.strip()]
+        if not normalized_emails:
+            return []
+
+        emails_csv = ",".join(normalized_emails)
+        payload = {"include_user_mediums": True, "emails": emails_csv}
+
+        output = await utils.make_API_call_to_CCow_and_get_response(
+            constants.URL_USERS_SEARCH_BY_EMAILS, "GET", payload, ctx=ctx
+        )
+        logger.debug("search_users_by_email_ids output: %s", output)
+
+        if isinstance(output, str):
+            logger.error("search_users_by_email_ids error: %s", output)
+            return output or "Facing internal error"
+
+        if not isinstance(output, dict):
+            return "Invalid response"
+
+        if output.get("error"):
+            return output.get("error", "Facing internal error")
+        if "Message" in output:
+            return output.get("Description") or output.get("Message", "Request failed")
+
+        items_raw = output.get("items", [])
+        if not isinstance(items_raw, list):
+            items_raw = []
+
+        result: list[vo.UserSearchResultVO] = []
+        for item in items_raw:
+            if not isinstance(item, dict):
+                continue
+
+            result.append(
+                vo.UserSearchResultVO(
+                    id=item.get("ID", "") or item.get("id", "") or "",
+                    username=item.get("username", "") or "",
+                    emailId=item.get("emailid", "") or item.get("emailId", "") or "",
+                )
+            )
+
+        return result
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("search_users_by_email_ids error: %s", e)
+        return "Facing internal error"
+
+
+@mcp.tool()
+async def validate_user_ids(
+    user_identifiers: List[str],
+    ctx: Context | None = None,
+) -> vo.ValidateUserIdentifiersResponseVO:
+    """
+    Validate user identifiers before assigning a form (step 3).
+
+    Args:
+        user_identifiers: User emails or identifiers to validate.
+        ctx: Optional request context.
+
+    Returns:
+        - validUserIds (List[str]): Resolved valid user IDs.
+        - inValidUserIdentifiers (List[str]): Identifiers that did not resolve.
+        - errorMsg (str): Optional backend validation message.
+        - error (Optional[str]): Error message if validation failed.
+    """
+    try:
+        logger.info("validate_user_ids")
+
+        cleaned = [u.strip() for u in user_identifiers if isinstance(u, str) and u.strip()]
+        payload = {"userIdentifiers": cleaned}
+
+        output = await utils.make_API_call_to_CCow_and_get_response(
+            constants.URL_USERS_CREATE_IDENTIFIERS, "POST", payload, ctx=ctx
+        )
+        logger.debug("validate_user_ids output: %s", output)
+
+        if isinstance(output, str):
+            return vo.ValidateUserIdentifiersResponseVO(error=output or "Facing internal error")
+
+        if not isinstance(output, dict):
+            return vo.ValidateUserIdentifiersResponseVO(error="Invalid response")
+
+        if output.get("error"):
+            return vo.ValidateUserIdentifiersResponseVO(
+                validUserIds=output.get("validUserIds", []),
+                inValidUserIdentifiers=output.get("inValidUserIdentifiers", []),
+                errorMsg=output.get("errorMsg", ""),
+                error=output.get("error", "Facing internal error"),
+            )
+
+        if "Message" in output:
+            return vo.ValidateUserIdentifiersResponseVO(
+                error=output.get("Description") or output.get("Message", "Request failed"),
+                validUserIds=output.get("validUserIds", []),
+                inValidUserIdentifiers=output.get("inValidUserIdentifiers", []),
+                errorMsg=output.get("errorMsg", ""),
+            )
+
+        valid_user_ids = output.get("validUserIds") or []
+        invalid_user_ids = output.get("inValidUserIdentifiers") or output.get("invalidUserIdentifiers") or []
+        error_msg = output.get("errorMsg") or ""
+
+        if not isinstance(valid_user_ids, list):
+            valid_user_ids = []
+        if not isinstance(invalid_user_ids, list):
+            invalid_user_ids = []
+
+        return vo.ValidateUserIdentifiersResponseVO(
+            validUserIds=[str(x) for x in valid_user_ids if x is not None],
+            inValidUserIdentifiers=[str(x) for x in invalid_user_ids if x is not None],
+            errorMsg=str(error_msg) if error_msg is not None else "",
+        )
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("validate_user_ids error: %s", e)
+        return vo.ValidateUserIdentifiersResponseVO(error="Facing internal error")
+
+
+@mcp.tool()
+async def assign_form(
+    user_ids: List[str],
+    form_id: str,
+    due_date: str,
+    purpose: str,
+    ctx: Context | None = None,
+) -> vo.AssignFormResponseVO:
+    """
+    Assign a form to users (step 4).
+
+    Args:
+        user_ids: User IDs to assign.
+        form_id: Target form ID.
+        due_date: Assignment due date string.
+        purpose: Assignment purpose text.
+        ctx: Optional request context.
+
+    Returns:
+        - ids (List[str]): Created assignment IDs.
+        - error (Optional[str]): Error message if assignment failed.
+    """
+    try:
+        logger.info("assign_form: form_id=%s, users=%d", form_id, len(user_ids or []))
+
+        normalized = normalize_assign_form_inputs(user_ids, due_date, purpose)
+        cleaned_user_ids, due_date_clean, purpose_clean = normalized
+        if cleaned_user_ids is None:
+            return vo.AssignFormResponseVO(error=purpose_clean or "Facing internal error")
+
+        elements_raw = await fetch_form_elements_for_assignment(form_id, ctx=ctx)
+        if isinstance(elements_raw, str):
+            return vo.AssignFormResponseVO(error=elements_raw or "Facing internal error")
+
+        element_ids = collect_assignable_element_ids(elements_raw)
+
+        payload = {
+            "userID": cleaned_user_ids,
+            "formID": form_id,
+            "dueDate": due_date_clean,
+            "shouldPreserveResponse": True,
+            "elementID": element_ids,
+            "freshAssignment": True,
+            "purpose": purpose_clean,
+            "enableSelfDelegate": True,
+        }
+
+        output = await utils.make_API_call_to_CCow_and_get_response(
+            constants.URL_USER_FORMS_ASSIGN, "POST", payload, ctx=ctx
+        )
+        logger.debug("assign_form output: %s", output)
+
+        ids, err = extract_assign_form_ids_and_error(output)
+        return vo.AssignFormResponseVO(ids=ids, error=err)
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("assign_form error: %s", e)
+        return vo.AssignFormResponseVO(error="Facing internal error")
 
 

--- a/utils/forms.py
+++ b/utils/forms.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import copy
+import traceback
+from typing import Any, List, Optional
+
+from fastmcp import Context
+
+from constants import constants
+from mcptypes import forms_tool_types as vo
+from utils import utils
+from utils.debug import logger
+
+
+def normalize_matrix_options(elements: List[Any]) -> None:
+    """Sync all Matrix child rows to the first row's options. Mutates in place, recurses into nested containers."""
+    if not elements:
+        return
+    for item in elements:
+        if not isinstance(item, dict):
+            continue
+        child_elements = item.get("elements")
+        if isinstance(child_elements, list):
+            if item.get("type") == "Matrix" and len(child_elements) > 0:
+                first_options = child_elements[0].get("options")
+                if first_options is not None:
+                    first_options_copy = copy.deepcopy(first_options)
+                    for child in child_elements[1:]:
+                        if isinstance(child, dict) and child.get("type") in (
+                            "Radio Button",
+                            "Checkbox",
+                        ):
+                            child["options"] = copy.deepcopy(first_options_copy)
+            normalize_matrix_options(child_elements)
+
+
+FORM_CATEGORY_TAG_KEY = "form_category"
+
+
+def parse_form_tags_from_raw(tags_raw: Any) -> Optional[List[vo.FormTagsItemVO]]:
+    """Convert raw API tag dicts into typed FormTagsItemVO list. Returns None if input is not a list."""
+    if not isinstance(tags_raw, list):
+        return None
+    tags_list: List[vo.FormTagsItemVO] = []
+    for t in tags_raw:
+        if isinstance(t, dict):
+            idx = t.get("index")
+            prim = t.get("primary")
+            tags_list.append(
+                vo.FormTagsItemVO(
+                    key=t.get("key", ""),
+                    values=t.get("values") if t.get("values") is not None else [],
+                    index=idx if isinstance(idx, int) else None,
+                    primary=prim if isinstance(prim, bool) else None,
+                )
+            )
+    return tags_list if tags_list else None
+
+
+def form_category_values(tags: Optional[List[vo.FormTagsItemVO]]) -> List[str]:
+    """Extract category values from a form's tags by the `form_category` key."""
+    if not tags:
+        return []
+    for t in tags:
+        if (t.key or "") == FORM_CATEGORY_TAG_KEY and t.values:
+            return list(t.values)
+    return []
+
+
+def merge_form_category_tag(
+    existing: Optional[List[vo.FormTagsItemVO]], category_value: str
+) -> List[vo.FormTagsItemVO]:
+    """Upsert the `form_category` tag in a tags list. Creates the tag if it doesn't exist."""
+    merged: List[vo.FormTagsItemVO] = []
+    found = False
+    if existing:
+        for t in existing:
+            if (t.key or "") == FORM_CATEGORY_TAG_KEY:
+                merged.append(
+                    vo.FormTagsItemVO(
+                        key=FORM_CATEGORY_TAG_KEY,
+                        values=[category_value],
+                        index=t.index if t.index is not None else 0,
+                        primary=t.primary if t.primary is not None else True,
+                    )
+                )
+                found = True
+            else:
+                merged.append(t.model_copy())
+    if not found:
+        merged.append(
+            vo.FormTagsItemVO(
+                key=FORM_CATEGORY_TAG_KEY,
+                values=[category_value],
+                index=0,
+                primary=True,
+            )
+        )
+    return merged
+
+
+def elements_from_raw(elements_raw: Any) -> Optional[List[vo.FormElementVO]]:
+    """Convert raw API element dicts into typed FormElementVO list. Returns None if input is not a list."""
+    if not isinstance(elements_raw, list):
+        return None
+    elements_list: List[vo.FormElementVO] = []
+    for elem in elements_raw:
+        if isinstance(elem, dict):
+            try:
+                elements_list.append(vo.FormElementVO(**elem))
+            except Exception:
+                pass
+    return elements_list
+
+
+async def fetch_form_raw(form_id: str, ctx: Context | None) -> dict | str:
+    """Fetch a complete form as raw dict by form_id. Returns error string on failure."""
+    payload = {"formId": form_id, "assignId": ""}
+    output = await utils.make_API_call_to_CCow_and_get_response(
+        constants.URL_FORMS_FETCH, "POST", payload, ctx=ctx
+    )
+    if isinstance(output, str):
+        return output
+    if isinstance(output, dict) and output.get("error"):
+        return output.get("error", "Facing internal error")
+    if isinstance(output, dict) and "Message" in output:
+        return output.get("Description") or output.get("Message", "Request failed")
+    if not isinstance(output, dict):
+        return "Invalid response"
+    return output
+
+
+async def is_form_assigned(form_id: str, ctx: Context | None) -> bool | str:
+    """Check whether a form is already assigned. Returns bool on success or an error string on failure."""
+    url = f"{constants.URL_CHECK_FORM_ASSIGNED}/{form_id}"
+    output = await utils.make_API_call_to_CCow_and_get_response(url, "GET", ctx=ctx)
+    if isinstance(output, str):
+        return output
+    if isinstance(output, dict) and output.get("error"):
+        return output.get("error", "Facing internal error")
+    if isinstance(output, dict) and "Message" in output:
+        return output.get("Description") or output.get("Message", "Request failed")
+    if not isinstance(output, dict):
+        return "Invalid response"
+    return bool(output.get("isFormAssigned", False))
+
+
+async def list_forms_impl(ctx: Context | None = None) -> vo.FormListVO:
+    """Fetch all forms and return as FormListVO. Used by list, category, and search flows."""
+    try:
+        logger.info("list_forms: \n")
+
+        output = await utils.make_API_call_to_CCow_and_get_response(constants.URL_FORMS, "GET", ctx)
+        logger.debug("list_forms output: {}\n".format(output))
+        if isinstance(output, str) or (isinstance(output, dict) and output.get("error")):
+            logger.error("list_forms error: {}\n".format(output))
+            return vo.FormListVO(error="Facing internal error")
+        if not isinstance(output, list):
+            logger.error("list_forms error: unexpected response shape\n")
+            return vo.FormListVO(error="Facing internal error")
+
+        forms: List[vo.FormVO] = []
+        for item in output:
+            if not isinstance(item, dict):
+                continue
+            tags = parse_form_tags_from_raw(item.get("tags"))
+            forms.append(
+                vo.FormVO(
+                    id=item.get("_id", "") or item.get("id", ""),
+                    name=item.get("name", ""),
+                    tags=tags,
+                )
+            )
+
+        return vo.FormListVO(forms=forms)
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("list_forms error: {}\n".format(e))
+        return vo.FormListVO(error="Facing internal error")
+
+
+async def update_form_impl(
+    form_id: str,
+    form: vo.UpdateFormVO,
+    ctx: Context | None = None,
+) -> vo.UpdateFormResponseVO:
+    """Persist a form update by sending the serialized payload. Used by form update and category flows."""
+    try:
+        logger.info("update_form: form_id=%s", form_id)
+
+        url = f"{constants.URL_FORMS}/{form_id}"
+        payload = form.to_api_payload()
+        if payload.get("elements"):
+            normalize_matrix_options(payload["elements"])
+        output = await utils.make_API_call_to_CCow_and_get_response(
+            url, "PUT", payload, ctx=ctx
+        )
+        logger.debug("update_form output: %s", output)
+
+        if isinstance(output, str):
+            logger.error("update_form error: %s", output)
+            return vo.UpdateFormResponseVO(error=output or "Facing internal error")
+        if isinstance(output, dict) and output.get("error"):
+            logger.error("update_form error: %s", output)
+            return vo.UpdateFormResponseVO(
+                error=output.get("error", "Facing internal error")
+            )
+        if isinstance(output, dict) and "Message" in output:
+            return vo.UpdateFormResponseVO(
+                error=output.get("Description") or output.get("Message", "Request failed")
+            )
+
+        return vo.UpdateFormResponseVO(
+            form=vo.FormVO(
+                id=form_id,
+                name=form.name or form.title or "",
+            )
+        )
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("update_form error: %s", e)
+        return vo.UpdateFormResponseVO(error="Facing internal error")
+
+
+def is_dynamic_option_active(status) -> bool:
+    """Check if a dynamic option set is active (True or "active")."""
+    if status is True:
+        return True
+    if isinstance(status, str) and str(status).lower() == "active":
+        return True
+    return False
+
+
+def should_collect_assignable_element_id(elem_type: str, children_value: Any) -> bool:
+    """Return True if this element type contributes its own ID to the assignment elementID list."""
+    if elem_type == "Statement Block":
+        return False
+    # Block is a container: recurse into its children, but do not collect block id itself.
+    if elem_type == "Block":
+        return False
+    # Prefer collecting Matrix child row IDs (already recursed into) rather than the Matrix container id.
+    if elem_type == "Matrix" and isinstance(children_value, list):
+        return False
+    return True
+
+
+def collect_assignable_element_ids(elements: Any) -> list[str]:
+    """Recursively collect answerable element IDs, skipping containers and statement blocks."""
+
+    if not isinstance(elements, list):
+        return []
+
+    collected: list[str] = []
+    for elem in elements:
+        if not isinstance(elem, dict):
+            continue
+
+        elem_type = elem.get("type") or ""
+        elem_id = elem.get("_id") or elem.get("id") or ""
+        children = elem.get("elements")
+
+        if elem_type == "Statement Block":
+            # Statement-only container; skip for assignment element collection.
+            continue
+
+        # Recurse first so child rows are captured.
+        if isinstance(children, list):
+            collected.extend(collect_assignable_element_ids(children))
+
+        # Add leaf/question elements only.
+        if elem_id and should_collect_assignable_element_id(elem_type, children):
+            collected.append(str(elem_id))
+
+    # Dedupe while preserving order.
+    seen: set[str] = set()
+    out: list[str] = []
+    for _id in collected:
+        if _id and _id not in seen:
+            out.append(_id)
+            seen.add(_id)
+    return out
+
+
+async def fetch_form_elements_for_assignment(form_id: str, ctx: Context | None) -> list[Any] | str:
+    """Fetch a form's raw elements list for building the assignment element ID set. Returns error string on failure."""
+    try:
+        payload = {"formId": form_id, "assignId": ""}
+        output = await utils.make_API_call_to_CCow_and_get_response(
+            constants.URL_FORMS_FETCH, "POST", payload, ctx=ctx
+        )
+
+        if isinstance(output, str):
+            return output
+        if isinstance(output, dict) and output.get("error"):
+            return output.get("error", "Facing internal error")
+        if isinstance(output, dict) and "Message" in output:
+            return output.get("Description") or output.get("Message", "Request failed")
+        if not isinstance(output, dict):
+            return "Invalid response"
+
+        elements_raw = output.get("elements") or []
+        return elements_raw if isinstance(elements_raw, list) else []
+    except Exception as e:
+        logger.error(traceback.format_exc())
+        logger.error("fetch_form_elements_for_assignment error: %s", e)
+        return "Facing internal error"
+
+
+def normalize_assign_form_inputs(
+    user_ids: List[str],
+    due_date: str,
+    purpose: str,
+) -> tuple[list[str], str, str] | tuple[None, None, str]:
+    """Validate and clean assign-form inputs. Returns (None, None, error) on validation failure."""
+    cleaned_user_ids = [u.strip() for u in user_ids if isinstance(u, str) and u.strip()]
+    if not cleaned_user_ids:
+        return None, None, "No valid user IDs provided"
+
+    due_date_clean = due_date.strip() if isinstance(due_date, str) else ""
+    if not due_date_clean:
+        return None, None, "due_date is required"
+
+    purpose_clean = purpose.strip() if isinstance(purpose, str) else ""
+    return cleaned_user_ids, due_date_clean, purpose_clean
+
+
+def extract_assign_form_ids_and_error(output: Any) -> tuple[list[str], str]:
+    """Parse created assignment IDs from the assign-form response. Returns (ids, error_string)."""
+    if isinstance(output, str):
+        return [], output or "Facing internal error"
+
+    if not isinstance(output, dict):
+        return [], "Invalid response"
+
+    if output.get("error"):
+        return [], output.get("error", "Facing internal error")
+
+    if "Message" in output:
+        return [], output.get("Description") or output.get("Message", "Request failed")
+
+    ids = output.get("ids") or output.get("IDs") or output.get("ID") or []
+    if not isinstance(ids, list):
+        ids = []
+
+    return [str(i) for i in ids if i is not None], ""


### PR DESCRIPTION
Refactor form handling and documentation updates
- Updated form knowledge documentation for clarity and structure.
- Refactored forms.py.
- Removed unused import from main.py.

Form MCP tools added:
- `get_configurations_for_forms`
- `clone_form`
- `update_form_configuration`
- `list_user_blocks`
- `search_users_by_email_ids`
- `validate_user_ids`
- `assign_form`

